### PR TITLE
feat: add --summary param to node edit for non-interactive agent use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 .DS_Store
+.claude

--- a/.memex/graph.json
+++ b/.memex/graph.json
@@ -21,6 +21,10 @@
     {
       "from": "925f8e38-6ed4-4bae-9424-2dc672c9cb64",
       "to": "173a43aa-789f-498f-b46f-2eafc8c6c646"
+    },
+    {
+      "from": "173a43aa-789f-498f-b46f-2eafc8c6c646",
+      "to": "18f50221-c31f-4c7f-8d53-5ea9c91e01ff"
     }
   ]
 }

--- a/.memex/nodes/18f50221-c31f-4c7f-8d53-5ea9c91e01ff.json
+++ b/.memex/nodes/18f50221-c31f-4c7f-8d53-5ea9c91e01ff.json
@@ -1,0 +1,29 @@
+{
+  "id": "18f50221-c31f-4c7f-8d53-5ea9c91e01ff",
+  "parent_ids": [
+    "173a43aa-789f-498f-b46f-2eafc8c6c646"
+  ],
+  "git_ref": "feat/node-edit-noninteractive (170bc909)",
+  "created_at": "2026-04-11T05:11:42.220272Z",
+  "updated_at": "2026-04-11T05:13:31.816022Z",
+  "summary": {
+    "goal": "Add --summary param to node edit for non-interactive agent use; add .claude to .gitignore",
+    "decisions": [
+      "Added --summary <TOML> flag to `memex node edit` that accepts a full NodeSummaryToml TOML string, bypassing the interactive editor",
+      "When --summary is absent, behavior is unchanged (opens $EDITOR)",
+      "Parsing uses the existing NodeSummaryToml/NodeSummary conversion path — no new types needed",
+      "Added Context import to node.rs for error annotation; added NodeSummary to the use list",
+      "Added .claude to .gitignore so Claude Code session files are not tracked"
+    ],
+    "rejected_approaches": [],
+    "open_threads": [],
+    "key_artifacts": [
+      "src/main.rs",
+      "src/commands/node.rs",
+      ".gitignore"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/src/commands/node.rs
+++ b/src/commands/node.rs
@@ -1,9 +1,9 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use chrono::Utc;
 
 use crate::editor;
 use crate::git;
-use crate::models::{ConversationNode, NodeStatus};
+use crate::models::{ConversationNode, NodeStatus, NodeSummary};
 use crate::store::GraphStore;
 
 pub fn create(
@@ -68,13 +68,21 @@ pub fn create(
     Ok(())
 }
 
-pub fn edit(id: Option<&str>) -> Result<()> {
+pub fn edit(id: Option<&str>, summary_toml: Option<&str>) -> Result<()> {
+    use crate::models::NodeSummaryToml;
+
     let store = GraphStore::open_from_cwd()?;
     let node_id = store.resolve_node_id(id)?;
     let mut node = store.load_node(node_id)?;
 
-    println!("Opening editor to edit node {}...", node.short_id());
-    let summary = editor::edit_node_summary(Some(&node.summary))?;
+    let summary = if let Some(toml_str) = summary_toml {
+        let parsed: NodeSummaryToml =
+            toml::from_str(toml_str).context("Failed to parse --summary TOML")?;
+        NodeSummary::from(parsed)
+    } else {
+        println!("Opening editor to edit node {}...", node.short_id());
+        editor::edit_node_summary(Some(&node.summary))?
+    };
 
     node.summary = summary;
     node.updated_at = Utc::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,10 @@ enum NodeCommands {
     Edit {
         /// Node ID (defaults to active node)
         id: Option<String>,
+
+        /// Summary as a TOML string (skips editor; for non-interactive/agent use)
+        #[arg(long)]
+        summary: Option<String>,
     },
 
     /// Show a node's full summary
@@ -140,7 +144,9 @@ fn run(cli: Cli) -> Result<()> {
                 &tags,
                 goal.as_deref(),
             ),
-            NodeCommands::Edit { id } => commands::node::edit(id.as_deref()),
+            NodeCommands::Edit { id, summary } => {
+                commands::node::edit(id.as_deref(), summary.as_deref())
+            }
             NodeCommands::Show { id } => commands::node::show(id.as_deref()),
             NodeCommands::List => commands::node::list(),
             NodeCommands::Resolve { id } => {


### PR DESCRIPTION
Adds a --summary <TOML> flag to `memex node edit` that accepts a full NodeSummaryToml-formatted TOML string directly, bypassing the interactive editor. When omitted, behavior is unchanged. Also adds .claude to .gitignore.