### PR TITLE
chore: commit orphaned memex node updates for docs/readme-improvement

### DIFF
--- a/.memex/nodes/abb28756-4345-486f-8ee9-96489c16eb69.json
+++ b/.memex/nodes/abb28756-4345-486f-8ee9-96489c16eb69.json
@@ -5,14 +5,16 @@
   ],
   "git_ref": "docs/readme-improvement (415581b9)",
   "created_at": "2026-04-12T04:42:11.020472Z",
-  "updated_at": "2026-04-12T04:43:05.951124Z",
+  "updated_at": "2026-04-12T04:51:55.377546Z",
   "summary": {
     "goal": "Improve README to document all existing features (tags, additive edit flags, context formats) and generalize the workflow section",
     "decisions": [
       "Replaced flat command table with subsections including all flags",
       "Generalized workflow section to apply to any project, not just memex-on-memex",
       "Documented tags, additive edit flags, and context format options that were previously undocumented",
-      "Merged What gets committed and Storage layout into single Storage section"
+      "Merged What gets committed and Storage layout into single Storage section",
+      "Removed unused web_port from config and models — separate commit from docs per CLAUDE.md convention",
+      "Removed transcripts directory reference from Storage table — unused feature"
     ],
     "rejected_approaches": [],
     "open_threads": [],


### PR DESCRIPTION
Captures two decisions that were recorded after the last commit on this branch: removal of unused web_port and the transcripts directory reference.