### PR TITLE
feat: add unit and integration tests with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: cargo test
+        run: cargo test --all-targets
+        env:
+          # /usr/bin/true exits 0 immediately — prevents any editor invocation from blocking CI
+          EDITOR: true

--- a/.memex/graph.json
+++ b/.memex/graph.json
@@ -63,7 +63,7 @@
       "to": "58cafd34-05c1-4bc6-adcf-c2a86d7d2ee3"
     },
     {
-      "from": "58cafd34-05c1-4bc6-adcf-c2a86d7d2ee3",
+      "from": "8403a5cb-721b-4c62-b019-2d02ecff7c82",
       "to": "6b5dfbf7-0a77-47ab-bfa1-be67cf9f8eb2"
     }
   ]

--- a/.memex/graph.json
+++ b/.memex/graph.json
@@ -61,6 +61,10 @@
     {
       "from": "2a16cfa5-528f-49e0-9dc4-94d2a1197747",
       "to": "58cafd34-05c1-4bc6-adcf-c2a86d7d2ee3"
+    },
+    {
+      "from": "58cafd34-05c1-4bc6-adcf-c2a86d7d2ee3",
+      "to": "6b5dfbf7-0a77-47ab-bfa1-be67cf9f8eb2"
     }
   ]
 }

--- a/.memex/nodes/6b5dfbf7-0a77-47ab-bfa1-be67cf9f8eb2.json
+++ b/.memex/nodes/6b5dfbf7-0a77-47ab-bfa1-be67cf9f8eb2.json
@@ -1,7 +1,7 @@
 {
   "id": "6b5dfbf7-0a77-47ab-bfa1-be67cf9f8eb2",
   "parent_ids": [
-    "58cafd34-05c1-4bc6-adcf-c2a86d7d2ee3"
+    "8403a5cb-721b-4c62-b019-2d02ecff7c82"
   ],
   "git_ref": "feat/add-tests (c49d630f)",
   "created_at": "2026-04-12T22:59:28.453604Z",

--- a/.memex/nodes/6b5dfbf7-0a77-47ab-bfa1-be67cf9f8eb2.json
+++ b/.memex/nodes/6b5dfbf7-0a77-47ab-bfa1-be67cf9f8eb2.json
@@ -1,0 +1,32 @@
+{
+  "id": "6b5dfbf7-0a77-47ab-bfa1-be67cf9f8eb2",
+  "parent_ids": [
+    "58cafd34-05c1-4bc6-adcf-c2a86d7d2ee3"
+  ],
+  "git_ref": "feat/add-tests (c49d630f)",
+  "created_at": "2026-04-12T22:59:28.453604Z",
+  "updated_at": "2026-04-12T23:06:55.091745Z",
+  "summary": {
+    "goal": "Introduce unit and integration tests with CI",
+    "decisions": [
+      "Add assert_cmd + predicates as dev-dependencies (tempfile already in deps)",
+      "Use pub(crate) to expose find_path, trim_path, highlight for in-module unit tests",
+      "Unit tests inline in modules; integration tests in tests/integration_tests.rs via assert_cmd",
+      "CI runs fmt check, clippy -D warnings, and cargo test --all-targets on ubuntu-latest"
+    ],
+    "rejected_approaches": [],
+    "open_threads": [],
+    "key_artifacts": [
+      "Cargo.toml",
+      "src/models.rs",
+      "src/store.rs",
+      "src/commands/context.rs",
+      "src/commands/search.rs",
+      "tests/integration_tests.rs",
+      ".github/workflows/ci.yml"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +77,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +102,17 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -168,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +235,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -334,14 +384,22 @@ name = "memex"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "chrono",
  "clap",
+ "predicates",
  "serde",
  "serde_json",
  "tempfile",
  "toml",
  "uuid",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-traits"
@@ -363,6 +421,36 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -397,6 +485,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
@@ -512,6 +629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +703,15 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ chrono = { version = "0.4", features = ["serde"] }
 anyhow = "1"
 toml = "0.8"
 tempfile = "3"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -53,7 +53,7 @@ pub fn run(id: Option<&str>, format: OutputFormat, depth: usize) -> Result<()> {
 
 /// Trim the ancestor section (path[1..len-1]) to at most `depth` nodes,
 /// always keeping the root (path[0]) and target (path[last]).
-fn trim_path(path: Vec<Uuid>, depth: usize) -> Vec<Uuid> {
+pub(crate) fn trim_path(path: Vec<Uuid>, depth: usize) -> Vec<Uuid> {
     if path.len() <= 2 {
         return path;
     }
@@ -69,7 +69,7 @@ fn trim_path(path: Vec<Uuid>, depth: usize) -> Vec<Uuid> {
 }
 
 /// Find the path (list of node IDs) from `start` to `target` using BFS.
-fn find_path(
+pub(crate) fn find_path(
     start: Uuid,
     target: Uuid,
     node_map: &HashMap<Uuid, &ConversationNode>,
@@ -215,10 +215,7 @@ fn generate_markdown(
     Ok(out)
 }
 
-fn generate_xml(
-    path: &[Uuid],
-    node_map: &HashMap<Uuid, &ConversationNode>,
-) -> Result<String> {
+fn generate_xml(path: &[Uuid], node_map: &HashMap<Uuid, &ConversationNode>) -> Result<String> {
     let mut out = String::new();
     out.push_str("<memex_context>\n");
 
@@ -331,10 +328,7 @@ fn generate_xml(
     Ok(out)
 }
 
-fn generate_plain(
-    path: &[Uuid],
-    node_map: &HashMap<Uuid, &ConversationNode>,
-) -> Result<String> {
+fn generate_plain(path: &[Uuid], node_map: &HashMap<Uuid, &ConversationNode>) -> Result<String> {
     let mut out = String::new();
 
     if path.is_empty() {
@@ -420,4 +414,194 @@ fn xml_escape(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{NodeStatus, NodeSummary};
+    use chrono::Utc;
+
+    fn make_node(id: Uuid, parent_ids: Vec<Uuid>) -> ConversationNode {
+        ConversationNode {
+            id,
+            parent_ids,
+            git_ref: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            summary: NodeSummary {
+                goal: format!("Goal {}", &id.to_string()[..8]),
+                ..Default::default()
+            },
+            raw_transcript_ref: None,
+            tags: vec![],
+            status: NodeStatus::Active,
+        }
+    }
+
+    fn node_map(nodes: &[ConversationNode]) -> HashMap<Uuid, &ConversationNode> {
+        nodes.iter().map(|n| (n.id, n)).collect()
+    }
+
+    // --- find_path ---
+
+    #[test]
+    fn find_path_start_equals_target() {
+        let id = Uuid::new_v4();
+        let n = make_node(id, vec![]);
+        let nodes = vec![n];
+        let map = node_map(&nodes);
+        assert_eq!(find_path(id, id, &map), Some(vec![id]));
+    }
+
+    #[test]
+    fn find_path_direct_parent_child() {
+        let root_id = Uuid::new_v4();
+        let child_id = Uuid::new_v4();
+        let root = make_node(root_id, vec![]);
+        let child = make_node(child_id, vec![root_id]);
+        let nodes = vec![root, child];
+        let map = node_map(&nodes);
+        assert_eq!(
+            find_path(root_id, child_id, &map),
+            Some(vec![root_id, child_id])
+        );
+    }
+
+    #[test]
+    fn find_path_multi_hop() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let c = Uuid::new_v4();
+        let na = make_node(a, vec![]);
+        let nb = make_node(b, vec![a]);
+        let nc = make_node(c, vec![b]);
+        let nodes = vec![na, nb, nc];
+        let map = node_map(&nodes);
+        assert_eq!(find_path(a, c, &map), Some(vec![a, b, c]));
+    }
+
+    #[test]
+    fn find_path_branching_dag() {
+        let root = Uuid::new_v4();
+        let b1 = Uuid::new_v4();
+        let b2 = Uuid::new_v4();
+        let g = Uuid::new_v4();
+        let n_root = make_node(root, vec![]);
+        let n_b1 = make_node(b1, vec![root]);
+        let n_b2 = make_node(b2, vec![root]);
+        let n_g = make_node(g, vec![b2]);
+        let nodes = vec![n_root, n_b1, n_b2, n_g];
+        let map = node_map(&nodes);
+        let path = find_path(root, g, &map).unwrap();
+        assert_eq!(path[0], root);
+        assert_eq!(*path.last().unwrap(), g);
+        assert!(path.contains(&b2));
+        assert!(!path.contains(&b1));
+    }
+
+    #[test]
+    fn find_path_unreachable_target_returns_singleton() {
+        let start = Uuid::new_v4();
+        let target = Uuid::new_v4();
+        let n_start = make_node(start, vec![]);
+        let n_target = make_node(target, vec![]); // no relationship to start
+        let nodes = vec![n_start, n_target];
+        let map = node_map(&nodes);
+        // Contract: fallback returns Some([target]) when target is not reachable from start
+        assert_eq!(find_path(start, target, &map), Some(vec![target]));
+    }
+
+    // --- trim_path ---
+
+    #[test]
+    fn trim_path_empty() {
+        let result: Vec<Uuid> = trim_path(vec![], 5);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn trim_path_single_node() {
+        let a = Uuid::new_v4();
+        assert_eq!(trim_path(vec![a], 2), vec![a]);
+    }
+
+    #[test]
+    fn trim_path_two_nodes_any_depth() {
+        let (a, b) = (Uuid::new_v4(), Uuid::new_v4());
+        // Early return fires regardless of depth
+        assert_eq!(trim_path(vec![a, b], 0), vec![a, b]);
+        assert_eq!(trim_path(vec![a, b], 99), vec![a, b]);
+    }
+
+    #[test]
+    fn trim_path_within_depth() {
+        let (r, a1, a2, t) = (
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        );
+        let path = vec![r, a1, a2, t];
+        // 2 ancestors, depth=3 → no trimming
+        assert_eq!(trim_path(path.clone(), 3), path);
+    }
+
+    #[test]
+    fn trim_path_truncates_oldest() {
+        let (r, a1, a2, a3, t) = (
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        );
+        let path = vec![r, a1, a2, a3, t];
+        // 3 ancestors, depth=2 → skip oldest (a1), keep [a2, a3]
+        assert_eq!(trim_path(path, 2), vec![r, a2, a3, t]);
+    }
+
+    #[test]
+    fn trim_path_depth_zero() {
+        let (r, a1, a2, t) = (
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        );
+        let path = vec![r, a1, a2, t];
+        // depth=0 → no ancestors kept, just root and target
+        assert_eq!(trim_path(path, 0), vec![r, t]);
+    }
+
+    // --- OutputFormat ---
+
+    #[test]
+    fn output_format_from_str_variants() {
+        assert_eq!(
+            OutputFormat::from_str("markdown").unwrap(),
+            OutputFormat::Markdown
+        );
+        assert_eq!(
+            OutputFormat::from_str("md").unwrap(),
+            OutputFormat::Markdown
+        );
+        assert_eq!(
+            OutputFormat::from_str("MARKDOWN").unwrap(),
+            OutputFormat::Markdown
+        );
+        assert_eq!(OutputFormat::from_str("xml").unwrap(), OutputFormat::Xml);
+        assert_eq!(
+            OutputFormat::from_str("plain").unwrap(),
+            OutputFormat::Plain
+        );
+        assert_eq!(OutputFormat::from_str("text").unwrap(), OutputFormat::Plain);
+    }
+
+    #[test]
+    fn output_format_from_str_invalid() {
+        let result = OutputFormat::from_str("json");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unknown format"));
+    }
 }

--- a/src/commands/node.rs
+++ b/src/commands/node.rs
@@ -77,7 +77,7 @@ pub fn edit(
     open_threads: &[String],
     rejected: &[String],
 ) -> Result<()> {
-    use crate::models::{RejectedApproach, NodeSummaryToml};
+    use crate::models::{NodeSummaryToml, RejectedApproach};
 
     let has_additive = goal.is_some()
         || !decisions.is_empty()

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -95,7 +95,7 @@ pub fn run(query: &str) -> Result<()> {
 }
 
 /// Simple case-insensitive highlight: wraps matches in >> << markers.
-fn highlight(text: &str, query: &str) -> String {
+pub(crate) fn highlight(text: &str, query: &str) -> String {
     let lower = text.to_lowercase();
     let query_lower = query.to_lowercase();
     let mut result = String::new();
@@ -111,4 +111,55 @@ fn highlight(text: &str, query: &str) -> String {
     }
     result.push_str(&text[pos..]);
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn highlight_exact_match() {
+        assert_eq!(highlight("hello world", "world"), "hello >>world<<");
+    }
+
+    #[test]
+    fn highlight_case_insensitive() {
+        assert_eq!(highlight("Hello World", "hello"), ">>Hello<< World");
+    }
+
+    #[test]
+    fn highlight_multiple_occurrences() {
+        assert_eq!(highlight("foo bar foo", "foo"), ">>foo<< bar >>foo<<");
+    }
+
+    #[test]
+    fn highlight_no_match() {
+        assert_eq!(highlight("hello world", "xyz"), "hello world");
+    }
+
+    #[test]
+    fn highlight_empty_text() {
+        assert_eq!(highlight("", "foo"), "");
+    }
+
+    #[test]
+    fn highlight_match_at_start() {
+        assert_eq!(highlight("start of string", "start"), ">>start<< of string");
+    }
+
+    #[test]
+    fn highlight_match_at_end() {
+        assert_eq!(highlight("at the end", "end"), "at the >>end<<");
+    }
+
+    #[test]
+    fn highlight_entire_string() {
+        assert_eq!(highlight("exact", "exact"), ">>exact<<");
+    }
+
+    #[test]
+    fn highlight_multibyte_utf8_smoke() {
+        // "café" has a 2-byte é; the match is after it — verify no byte-boundary panic
+        assert_eq!(highlight("café latte", "latte"), "café >>latte<<");
+    }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -214,3 +214,181 @@ impl Default for StorageConfig {
 pub struct UiConfig {
     pub editor: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_status_display() {
+        assert_eq!(format!("{}", NodeStatus::Active), "Active");
+        assert_eq!(format!("{}", NodeStatus::Resolved), "Resolved");
+        assert_eq!(format!("{}", NodeStatus::Abandoned), "Abandoned");
+    }
+
+    #[test]
+    fn node_status_icons() {
+        let mut node = ConversationNode::new(vec![], None, vec![]);
+        node.status = NodeStatus::Active;
+        assert_eq!(node.status_icon(), "●");
+        node.status = NodeStatus::Resolved;
+        assert_eq!(node.status_icon(), "✓");
+        node.status = NodeStatus::Abandoned;
+        assert_eq!(node.status_icon(), "✗");
+    }
+
+    #[test]
+    fn node_status_serde_roundtrip() {
+        let json = serde_json::to_string(&NodeStatus::Resolved).unwrap();
+        assert_eq!(json, "\"Resolved\"");
+        let back: NodeStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, NodeStatus::Resolved);
+
+        let json2 = serde_json::to_string(&NodeStatus::Abandoned).unwrap();
+        assert_eq!(json2, "\"Abandoned\"");
+        let back2: NodeStatus = serde_json::from_str(&json2).unwrap();
+        assert_eq!(back2, NodeStatus::Abandoned);
+    }
+
+    #[test]
+    fn short_id_is_8_chars() {
+        let node = ConversationNode::new(vec![], None, vec![]);
+        let short = node.short_id();
+        assert_eq!(short.len(), 8);
+        assert!(node.id.to_string().starts_with(&short));
+    }
+
+    #[test]
+    fn graph_add_edge() {
+        let mut g = Graph::new();
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        g.add_edge(a, b);
+        assert_eq!(g.edges.len(), 1);
+        assert_eq!(g.edges[0].from, a);
+        assert_eq!(g.edges[0].to, b);
+    }
+
+    #[test]
+    fn graph_add_multiple_edges() {
+        let mut g = Graph::new();
+        let (a, b, c) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+        g.add_edge(a, b);
+        g.add_edge(a, c);
+        g.add_edge(b, c);
+        assert_eq!(g.edges.len(), 3);
+    }
+
+    #[test]
+    fn node_summary_default_is_empty() {
+        let s = NodeSummary::default();
+        assert!(s.goal.is_empty());
+        assert!(s.decisions.is_empty());
+        assert!(s.rejected_approaches.is_empty());
+        assert!(s.open_threads.is_empty());
+        assert!(s.key_artifacts.is_empty());
+    }
+
+    #[test]
+    fn node_summary_toml_roundtrip() {
+        let original = NodeSummary {
+            goal: "Build a parser".to_string(),
+            decisions: vec!["Use pest".to_string(), "Hand-roll lexer".to_string()],
+            rejected_approaches: vec![RejectedApproach {
+                description: "nom combinator".to_string(),
+                reason: "Too verbose".to_string(),
+            }],
+            open_threads: vec!["Error recovery strategy?".to_string()],
+            key_artifacts: vec!["src/parser.rs".to_string()],
+        };
+
+        let toml_repr = NodeSummaryToml::from(&original);
+        let roundtripped = NodeSummary::from(toml_repr);
+
+        assert_eq!(roundtripped.goal, original.goal);
+        assert_eq!(roundtripped.decisions, original.decisions);
+        assert_eq!(roundtripped.open_threads, original.open_threads);
+        assert_eq!(roundtripped.key_artifacts, original.key_artifacts);
+        assert_eq!(roundtripped.rejected_approaches.len(), 1);
+        assert_eq!(
+            roundtripped.rejected_approaches[0].description,
+            original.rejected_approaches[0].description
+        );
+        assert_eq!(
+            roundtripped.rejected_approaches[0].reason,
+            original.rejected_approaches[0].reason
+        );
+    }
+
+    #[test]
+    fn node_summary_toml_roundtrip_empty() {
+        let original = NodeSummary::default();
+        let roundtripped = NodeSummary::from(NodeSummaryToml::from(&original));
+        assert!(roundtripped.goal.is_empty());
+        assert!(roundtripped.decisions.is_empty());
+        assert!(roundtripped.rejected_approaches.is_empty());
+    }
+
+    #[test]
+    fn node_json_roundtrip() {
+        let mut node = ConversationNode::new(
+            vec![Uuid::new_v4()],
+            Some("main (abc12345)".to_string()),
+            vec!["feat".to_string()],
+        );
+        node.summary.goal = "Ship the feature".to_string();
+        node.summary.decisions.push("Use async".to_string());
+        node.summary.rejected_approaches.push(RejectedApproach {
+            description: "Threads".to_string(),
+            reason: "Complexity".to_string(),
+        });
+        node.status = NodeStatus::Resolved;
+
+        let json = serde_json::to_string(&node).unwrap();
+        let back: ConversationNode = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(back.id, node.id);
+        assert_eq!(back.parent_ids, node.parent_ids);
+        assert_eq!(back.git_ref, node.git_ref);
+        assert_eq!(back.tags, node.tags);
+        assert_eq!(back.status, NodeStatus::Resolved);
+        assert_eq!(back.summary.goal, "Ship the feature");
+        assert_eq!(back.summary.decisions, vec!["Use async"]);
+        assert_eq!(back.summary.rejected_approaches.len(), 1);
+        assert_eq!(back.summary.rejected_approaches[0].description, "Threads");
+    }
+
+    #[test]
+    fn graph_json_roundtrip() {
+        let mut g = Graph::new();
+        let root = Uuid::new_v4();
+        let child = Uuid::new_v4();
+        g.root_id = Some(root);
+        g.add_edge(root, child);
+        g.add_edge(child, Uuid::new_v4());
+
+        let json = serde_json::to_string(&g).unwrap();
+        let back: Graph = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(back.root_id, Some(root));
+        assert_eq!(back.edges.len(), 2);
+        assert_eq!(back.edges[0].from, root);
+        assert_eq!(back.edges[0].to, child);
+    }
+
+    #[test]
+    fn state_json_roundtrip() {
+        let id = Uuid::new_v4();
+        let s = State {
+            active_id: Some(id),
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: State = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.active_id, Some(id));
+
+        let empty = State::new();
+        let json2 = serde_json::to_string(&empty).unwrap();
+        let back2: State = serde_json::from_str(&json2).unwrap();
+        assert!(back2.active_id.is_none());
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -208,5 +208,283 @@ impl GraphStore {
             ),
         }
     }
+}
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, TimeZone, Utc};
+    use tempfile::TempDir;
+
+    fn make_store() -> (TempDir, GraphStore) {
+        let tmp = TempDir::new().unwrap();
+        let store = GraphStore::open(tmp.path().to_path_buf());
+        store.initialize().unwrap();
+        (tmp, store)
+    }
+
+    // --- Discovery ---
+
+    #[test]
+    fn find_returns_none_without_memex() {
+        let tmp = TempDir::new().unwrap();
+        assert!(GraphStore::find(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn find_returns_root_when_memex_present() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".memex")).unwrap();
+        let found = GraphStore::find(tmp.path()).unwrap();
+        assert_eq!(found, tmp.path());
+    }
+
+    #[test]
+    fn find_walks_up_tree() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".memex")).unwrap();
+        let nested = tmp.path().join("a").join("b").join("c");
+        fs::create_dir_all(&nested).unwrap();
+        let found = GraphStore::find(&nested).unwrap();
+        assert_eq!(found, tmp.path());
+    }
+
+    // --- Initialization ---
+
+    #[test]
+    fn is_initialized_false_before_init() {
+        let tmp = TempDir::new().unwrap();
+        let store = GraphStore::open(tmp.path().to_path_buf());
+        assert!(!store.is_initialized());
+    }
+
+    #[test]
+    fn is_initialized_true_after_init() {
+        let (_tmp, store) = make_store();
+        assert!(store.is_initialized());
+    }
+
+    #[test]
+    fn initialize_creates_structure() {
+        let tmp = TempDir::new().unwrap();
+        let store = GraphStore::open(tmp.path().to_path_buf());
+        store.initialize().unwrap();
+        assert!(store.memex_dir().is_dir());
+        assert!(store.nodes_dir().is_dir());
+        assert!(store.config_path().exists());
+        let config_content = fs::read_to_string(store.config_path()).unwrap();
+        assert!(!config_content.is_empty());
+    }
+
+    #[test]
+    fn initialize_does_not_overwrite_config() {
+        let (_tmp, store) = make_store();
+        fs::write(store.config_path(), "custom = true").unwrap();
+        store.initialize().unwrap();
+        let content = fs::read_to_string(store.config_path()).unwrap();
+        assert_eq!(content, "custom = true");
+    }
+
+    // --- Graph I/O ---
+
+    #[test]
+    fn save_and_load_graph_roundtrip() {
+        let (_tmp, store) = make_store();
+        let mut g = Graph::new();
+        let root = Uuid::new_v4();
+        let child = Uuid::new_v4();
+        g.root_id = Some(root);
+        g.add_edge(root, child);
+        g.add_edge(child, Uuid::new_v4());
+
+        store.save_graph(&g).unwrap();
+        let loaded = store.load_graph().unwrap();
+
+        assert_eq!(loaded.root_id, Some(root));
+        assert_eq!(loaded.edges.len(), 2);
+        assert_eq!(loaded.edges[0].from, root);
+        assert_eq!(loaded.edges[0].to, child);
+    }
+
+    #[test]
+    fn load_graph_returns_empty_when_missing() {
+        let (_tmp, store) = make_store();
+        // graph.json was not written during initialize()
+        let g = store.load_graph().unwrap();
+        assert!(g.root_id.is_none());
+        assert!(g.edges.is_empty());
+    }
+
+    // --- Node I/O ---
+
+    #[test]
+    fn save_and_load_node_roundtrip() {
+        let (_tmp, store) = make_store();
+        let mut node = ConversationNode::new(vec![], None, vec![]);
+        node.summary.goal = "Test goal".to_string();
+        node.summary.decisions.push("Decision A".to_string());
+
+        store.save_node(&node).unwrap();
+        let loaded = store.load_node(node.id).unwrap();
+
+        assert_eq!(loaded.id, node.id);
+        assert_eq!(loaded.summary.goal, "Test goal");
+        assert_eq!(loaded.summary.decisions, vec!["Decision A"]);
+    }
+
+    #[test]
+    fn load_node_error_on_missing() {
+        let (_tmp, store) = make_store();
+        let result = store.load_node(Uuid::new_v4());
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Failed to read node"),
+            "unexpected error: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn load_all_nodes_empty_without_nodes() {
+        let (_tmp, store) = make_store();
+        let nodes = store.load_all_nodes().unwrap();
+        assert!(nodes.is_empty());
+    }
+
+    #[test]
+    fn load_all_nodes_sorted_by_created_at() {
+        let (_tmp, store) = make_store();
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+
+        let mut n1 = ConversationNode::new(vec![], None, vec![]);
+        n1.created_at = base;
+        n1.summary.goal = "First".to_string();
+
+        let mut n2 = ConversationNode::new(vec![], None, vec![]);
+        n2.created_at = base + Duration::seconds(10);
+        n2.summary.goal = "Second".to_string();
+
+        let mut n3 = ConversationNode::new(vec![], None, vec![]);
+        n3.created_at = base + Duration::seconds(20);
+        n3.summary.goal = "Third".to_string();
+
+        // Save in reverse order to ensure sorting is actually applied
+        store.save_node(&n3).unwrap();
+        store.save_node(&n1).unwrap();
+        store.save_node(&n2).unwrap();
+
+        let loaded = store.load_all_nodes().unwrap();
+        assert_eq!(loaded.len(), 3);
+        assert_eq!(loaded[0].summary.goal, "First");
+        assert_eq!(loaded[1].summary.goal, "Second");
+        assert_eq!(loaded[2].summary.goal, "Third");
+    }
+
+    #[test]
+    fn load_all_nodes_ignores_non_json_files() {
+        let (_tmp, store) = make_store();
+        let node = ConversationNode::new(vec![], None, vec![]);
+        store.save_node(&node).unwrap();
+        fs::write(store.nodes_dir().join("readme.txt"), "ignore me").unwrap();
+
+        let nodes = store.load_all_nodes().unwrap();
+        assert_eq!(nodes.len(), 1);
+    }
+
+    // --- State I/O ---
+
+    #[test]
+    fn save_and_load_state_roundtrip() {
+        let (_tmp, store) = make_store();
+        let id = Uuid::new_v4();
+        store.set_active_id(id).unwrap();
+        let active = store.get_active_id().unwrap();
+        assert_eq!(active, Some(id));
+    }
+
+    #[test]
+    fn load_state_returns_none_when_missing() {
+        let (_tmp, store) = make_store();
+        let state = store.load_state().unwrap();
+        assert!(state.active_id.is_none());
+    }
+
+    // --- ID resolution ---
+
+    #[test]
+    fn resolve_node_id_uses_active_when_none() {
+        let (_tmp, store) = make_store();
+        let node = ConversationNode::new(vec![], None, vec![]);
+        store.save_node(&node).unwrap();
+        store.set_active_id(node.id).unwrap();
+
+        let resolved = store.resolve_node_id(None).unwrap();
+        assert_eq!(resolved, node.id);
+    }
+
+    #[test]
+    fn resolve_node_id_errors_without_active() {
+        let (_tmp, store) = make_store();
+        let result = store.resolve_node_id(None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No active node"));
+    }
+
+    #[test]
+    fn resolve_node_id_uses_prefix() {
+        let (_tmp, store) = make_store();
+        let node = ConversationNode::new(vec![], None, vec![]);
+        store.save_node(&node).unwrap();
+
+        let resolved = store.resolve_node_id(Some(&node.short_id())).unwrap();
+        assert_eq!(resolved, node.id);
+    }
+
+    #[test]
+    fn find_node_by_prefix_exact_uuid() {
+        let (_tmp, store) = make_store();
+        let node = ConversationNode::new(vec![], None, vec![]);
+        store.save_node(&node).unwrap();
+
+        let found = store.find_node_id_by_prefix(&node.id.to_string()).unwrap();
+        assert_eq!(found, node.id);
+    }
+
+    #[test]
+    fn find_node_by_prefix_short() {
+        let (_tmp, store) = make_store();
+        let node = ConversationNode::new(vec![], None, vec![]);
+        store.save_node(&node).unwrap();
+
+        let prefix = &node.id.to_string()[..6];
+        let found = store.find_node_id_by_prefix(prefix).unwrap();
+        assert_eq!(found, node.id);
+    }
+
+    #[test]
+    fn find_node_by_prefix_ambiguous() {
+        let (_tmp, store) = make_store();
+        let mut n1 = ConversationNode::new(vec![], None, vec![]);
+        n1.id = Uuid::parse_str("aaaaaaaa-1111-1111-1111-111111111111").unwrap();
+        let mut n2 = ConversationNode::new(vec![], None, vec![]);
+        n2.id = Uuid::parse_str("aaaaaaaa-2222-2222-2222-222222222222").unwrap();
+
+        store.save_node(&n1).unwrap();
+        store.save_node(&n2).unwrap();
+
+        let result = store.find_node_id_by_prefix("aaaaaaaa");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Ambiguous"), "unexpected error: {}", msg);
+    }
+
+    #[test]
+    fn find_node_by_prefix_not_found() {
+        let (_tmp, store) = make_store();
+        let result = store.find_node_id_by_prefix("00000000");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("No node found"), "unexpected error: {}", msg);
+    }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,611 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn memex() -> Command {
+    Command::cargo_bin("memex").unwrap()
+}
+
+/// Initialize a memex repo in `dir` using stdin so no editor is opened.
+fn init_in(dir: &TempDir) {
+    memex()
+        .current_dir(dir.path())
+        .arg("init")
+        .write_stdin("My test project\n")
+        .assert()
+        .success();
+}
+
+/// Create a node with the given goal and return its short ID (first 8 chars).
+fn create_node(dir: &TempDir, goal: &str) -> String {
+    let output = memex()
+        .current_dir(dir.path())
+        .args(["node", "create", "--goal", goal])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    // "Created node: <full-uuid>\n"
+    text.lines()
+        .find(|l| l.starts_with("Created node:"))
+        .unwrap()
+        .split_whitespace()
+        .last()
+        .unwrap()[..8]
+        .to_string()
+}
+
+// ─── Init ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn init_creates_memex_directory() {
+    let tmp = TempDir::new().unwrap();
+    memex()
+        .current_dir(tmp.path())
+        .arg("init")
+        .write_stdin("My project\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Initialized .memex/"));
+
+    assert!(tmp.path().join(".memex").is_dir());
+    assert!(tmp.path().join(".memex/nodes").is_dir());
+    assert!(tmp.path().join(".memex/config.toml").exists());
+}
+
+#[test]
+fn init_twice_warns_already_exists() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    // Second init should exit 0 but warn on stderr
+    memex()
+        .current_dir(tmp.path())
+        .arg("init")
+        .write_stdin("irrelevant\n")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("already"));
+}
+
+#[test]
+fn command_without_init_fails() {
+    let tmp = TempDir::new().unwrap();
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "list"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No .memex directory found"));
+}
+
+// ─── Node create ─────────────────────────────────────────────────────────────
+
+#[test]
+fn node_create_with_goal_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    let short_id = create_node(&tmp, "Build a search index");
+
+    // Node file exists on disk
+    let nodes_dir = tmp.path().join(".memex/nodes");
+    let entries: Vec<_> = fs::read_dir(&nodes_dir)
+        .unwrap()
+        // init creates a root node, so look for the one matching our short_id
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().starts_with(&short_id))
+        .collect();
+    assert_eq!(entries.len(), 1, "expected node file for {short_id}");
+}
+
+#[test]
+fn node_create_sets_active() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "My active task");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("My active task"));
+}
+
+#[test]
+fn node_create_with_parent_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    let parent_id = create_node(&tmp, "Parent node");
+    let child_id = create_node(&tmp, "Child node");
+    // Re-create child with explicit parent (use `node create` with parent pointing to parent_id)
+    // (The previous create_node already set parent to the current active; re-verify via graph view)
+    let _ = child_id;
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["graph", "view"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&parent_id));
+}
+
+#[test]
+fn node_create_unknown_parent_fails() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "create", "--parent", "00000000", "--goal", "Orphan"])
+        .assert()
+        .failure();
+}
+
+// ─── Node edit ───────────────────────────────────────────────────────────────
+
+#[test]
+fn node_edit_goal_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Original goal");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "edit", "--goal", "Updated goal"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Updated goal"))
+        .stdout(predicate::str::contains("Original goal").not());
+}
+
+#[test]
+fn node_edit_decision_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Planning");
+
+    memex()
+        .current_dir(tmp.path())
+        .args([
+            "node",
+            "edit",
+            "--decision",
+            "Use PostgreSQL",
+            "--decision",
+            "Use Rust",
+        ])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Use PostgreSQL"))
+        .stdout(predicate::str::contains("Use Rust"));
+}
+
+#[test]
+fn node_edit_artifact_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Work");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "edit", "--artifact", "src/main.rs"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("src/main.rs"));
+}
+
+#[test]
+fn node_edit_open_thread_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Design");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "edit", "--open-thread", "How to handle auth?"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("How to handle auth?"));
+}
+
+#[test]
+fn node_edit_summary_and_goal_conflict() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Task");
+
+    memex()
+        .current_dir(tmp.path())
+        .args([
+            "node",
+            "edit",
+            "--summary",
+            r#"goal = "Full TOML"
+decisions = []
+rejected_approaches = []
+open_threads = []
+key_artifacts = []"#,
+            "--goal",
+            "conflicting",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("cannot be combined").or(predicate::str::contains("conflict")),
+        );
+}
+
+#[test]
+fn node_edit_empty_goal_fails() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Task");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "edit", "--goal", ""])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be empty").or(predicate::str::contains("empty")));
+}
+
+// ─── Node status ─────────────────────────────────────────────────────────────
+
+#[test]
+fn node_resolve_marks_resolved() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Task to resolve");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "resolve"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Resolved"));
+}
+
+#[test]
+fn node_resolve_already_resolved_errors() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Task");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "resolve"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "resolve"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("already resolved").or(predicate::str::contains("already")),
+        );
+}
+
+#[test]
+fn node_abandon_marks_abandoned() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Abandoned task");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "abandon"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Abandoned"));
+}
+
+#[test]
+fn node_reopen_resolved_node() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Task");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "resolve"])
+        .assert()
+        .success();
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "reopen"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Active"));
+}
+
+#[test]
+fn node_reopen_already_active_errors() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Task");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "reopen"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already active").or(predicate::str::contains("already")));
+}
+
+// ─── Node show / list ────────────────────────────────────────────────────────
+
+#[test]
+fn node_show_by_short_id() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    let short_id = create_node(&tmp, "Specific node");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show", &short_id])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Specific node"));
+}
+
+#[test]
+fn node_list_shows_all_nodes() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Alpha node");
+    create_node(&tmp, "Beta node");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alpha node"))
+        .stdout(predicate::str::contains("Beta node"));
+}
+
+#[test]
+fn node_list_marks_active() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Active node");
+
+    let output = memex()
+        .current_dir(tmp.path())
+        .args(["node", "list"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8(output).unwrap();
+    assert!(
+        text.lines().any(|l| l.starts_with('*')),
+        "Expected a line starting with '*' in:\n{text}"
+    );
+}
+
+// ─── Graph ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn graph_view_single_node() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Lone node");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["graph", "view"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Conversation Graph"))
+        .stdout(predicate::str::contains("Legend:"));
+}
+
+#[test]
+fn graph_view_tree_connectors() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    let parent_id = create_node(&tmp, "Parent");
+    let _child_id = create_node(&tmp, "Child"); // auto-parented to active (parent)
+    let _ = parent_id;
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["graph", "view"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("──"));
+}
+
+// ─── Search ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn search_finds_goal() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Build a database indexer");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["search", "database"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(">>database<<"));
+}
+
+#[test]
+fn search_case_insensitive() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Build a DATABASE indexer");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["search", "database"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(">>DATABASE<<"));
+}
+
+#[test]
+fn search_no_match() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Build a web server");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["search", "zzznomatch"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No nodes found matching"));
+}
+
+#[test]
+fn search_finds_decisions() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Design system");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "edit", "--decision", "Use microservices"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["search", "microservices"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("decision[0]"));
+}
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn context_markdown_output() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Root project");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["context", "--format", "markdown"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("## Project Context"))
+        .stdout(predicate::str::contains("**Goal:**"));
+}
+
+#[test]
+fn context_xml_output() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Root project");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["context", "--format", "xml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<memex_context>"))
+        .stdout(predicate::str::contains("<goal>"));
+}
+
+#[test]
+fn context_plain_output() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Root project");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["context", "--format", "plain"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PROJECT CONTEXT"));
+}
+
+#[test]
+fn context_invalid_format_fails() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["context", "--format", "json"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Unknown format"));
+}
+
+#[test]
+fn context_depth_trimming() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+
+    // Build a 4-level chain: root → level1 → level2 → current
+    let root_id = create_node(&tmp, "Root node");
+    let level1_id = create_node(&tmp, "Level one node");
+    let level2_id = create_node(&tmp, "Level two node");
+    let _current_id = create_node(&tmp, "Current node");
+    let _ = (root_id, level1_id, level2_id);
+
+    // --depth 1: only keep 1 ancestor between root and current → Level one should be trimmed
+    memex()
+        .current_dir(tmp.path())
+        .args(["context", "--format", "plain", "--depth", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Level one node").not())
+        .stdout(predicate::str::contains("Current node"));
+}


### PR DESCRIPTION
## Summary

- 57 unit tests inline in `models`, `store`, `commands/context`, `commands/search`
- 32 integration tests in `tests/integration_tests.rs` via `assert_cmd`, covering the full CLI end-to-end
- GitHub Actions CI (`.github/workflows/ci.yml`) running `fmt --check`, `clippy -D warnings`, and `cargo test --all-targets` on every push and PR to `main`

## Test plan

- [ ] CI triggers on this PR and all checks pass
- [ ] `cargo test --all-targets` passes locally (57 unit + 32 integration = 89 tests)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean