### PR TITLE
docs: add parent node selection examples to CLAUDE.md

### DIFF
--- a/.memex/graph.json
+++ b/.memex/graph.json
@@ -65,6 +65,10 @@
     {
       "from": "8403a5cb-721b-4c62-b019-2d02ecff7c82",
       "to": "6b5dfbf7-0a77-47ab-bfa1-be67cf9f8eb2"
+    },
+    {
+      "from": "58cafd34-05c1-4bc6-adcf-c2a86d7d2ee3",
+      "to": "269bfac9-e21c-42a3-8ed0-6bbc5ead6a17"
     }
   ]
 }

--- a/.memex/nodes/269bfac9-e21c-42a3-8ed0-6bbc5ead6a17.json
+++ b/.memex/nodes/269bfac9-e21c-42a3-8ed0-6bbc5ead6a17.json
@@ -1,0 +1,21 @@
+{
+  "id": "269bfac9-e21c-42a3-8ed0-6bbc5ead6a17",
+  "parent_ids": [
+    "58cafd34-05c1-4bc6-adcf-c2a86d7d2ee3"
+  ],
+  "git_ref": "docs/parent-node-examples (91b0e58a)",
+  "created_at": "2026-04-12T23:35:13.081887Z",
+  "updated_at": "2026-04-12T23:35:16.110114Z",
+  "summary": {
+    "goal": "Add parent node selection examples to CLAUDE.md",
+    "decisions": [],
+    "rejected_approaches": [],
+    "open_threads": [],
+    "key_artifacts": [
+      "CLAUDE.md"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,9 @@ This project tracks its own development using `memex`. Follow this pattern for e
    - If your work extends a specific prior feature, attach to that feature's node even if it isn't the tip
    - If your work is independent of recent changes, find the most recent resolved node whose scope your work builds on
    - If your work depends directly on what just landed, attach to the active node (the linear case, correct when the dependency is real)
+   - e.g. adding tests for the search command → parent is the node that implemented search, not documentation or cleanup nodes that landed after it
+   - e.g. fixing a crash in `node edit` → parent is the node that introduced `node edit`, not whatever resolved most recently
+   - e.g. adding a new `memex export` command → find the most recent node that touched the CLI structure; skip unrelated docs or refactors that followed it
 
 2. **Branch** - `git checkout -b <type>/<name>` from `main`
 


### PR DESCRIPTION
## Summary

- Adds three concrete examples to the parent node selection guidance in CLAUDE.md
- Covers the three most common failure modes: skipping the tip when docs followed a feature, going back to the origin node for a bug fix, and finding the right anchor for independent work

## Test plan

- [ ] Review the three added examples for clarity and conciseness