### PR TITLE
feat: add GitHub Action to enforce memex node creation on PRs

### DIFF
--- a/.github/workflows/memex-check.yml
+++ b/.github/workflows/memex-check.yml
@@ -1,0 +1,49 @@
+name: Verify memex node
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  memex-node-check:
+    name: Verify memex node created
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify memex node and graph.json
+        run: |
+          BASE=origin/${{ github.base_ref }}
+
+          # 1. New node files
+          NEW_NODES=$(git diff --name-only --diff-filter=A "$BASE"...HEAD -- '.memex/nodes/*.json')
+          if [ -z "$NEW_NODES" ]; then
+            echo "::error::No new memex node found in .memex/nodes/. Run: memex node create --parent <id> --goal \"<goal>\""
+            exit 1
+          fi
+          echo "New node(s) found: $NEW_NODES"
+
+          # 2. graph.json updated
+          GRAPH_CHANGED=$(git diff --name-only "$BASE"...HEAD -- '.memex/graph.json')
+          if [ -z "$GRAPH_CHANGED" ]; then
+            echo "::error::.memex/graph.json was not updated. Ensure memex node create was run."
+            exit 1
+          fi
+          echo "graph.json was updated."
+
+          # 3. Each new node is referenced in graph.json
+          FAILED=0
+          for NODE_PATH in $NEW_NODES; do
+            UUID=$(basename "$NODE_PATH" .json)
+            if jq -e --arg id "$UUID" \
+              '.root_id == $id or any(.edges[]; .from == $id or .to == $id)' \
+              .memex/graph.json > /dev/null 2>&1; then
+              echo "Node $UUID is referenced in graph.json."
+            else
+              echo "::error::Node $UUID is not referenced in graph.json."
+              FAILED=1
+            fi
+          done
+          exit $FAILED

--- a/.memex/graph.json
+++ b/.memex/graph.json
@@ -69,6 +69,10 @@
     {
       "from": "58cafd34-05c1-4bc6-adcf-c2a86d7d2ee3",
       "to": "269bfac9-e21c-42a3-8ed0-6bbc5ead6a17"
+    },
+    {
+      "from": "6b5dfbf7-0a77-47ab-bfa1-be67cf9f8eb2",
+      "to": "af5774e3-d353-477c-93ea-8f465e62028e"
     }
   ]
 }

--- a/.memex/nodes/af5774e3-d353-477c-93ea-8f465e62028e.json
+++ b/.memex/nodes/af5774e3-d353-477c-93ea-8f465e62028e.json
@@ -1,0 +1,25 @@
+{
+  "id": "af5774e3-d353-477c-93ea-8f465e62028e",
+  "parent_ids": [
+    "6b5dfbf7-0a77-47ab-bfa1-be67cf9f8eb2"
+  ],
+  "git_ref": "feat/memex-node-ci-check (b810aa9a)",
+  "created_at": "2026-04-13T03:39:10.395036Z",
+  "updated_at": "2026-04-13T03:39:35.221049Z",
+  "summary": {
+    "goal": "Add GitHub Action to enforce memex node creation on PRs",
+    "decisions": [
+      "separate workflow file (memex-check.yml) instead of adding a step to ci.yml — keeps Rust CI and workflow enforcement concerns independent",
+      "three checks in a single run step: (1) new node file added, (2) graph.json modified, (3) each node UUID present in graph.json as root_id or edge — covers both rooted and parented nodes",
+      "fetch-depth: 0 on checkout so origin/${{ github.base_ref }} is available for three-dot diff against HEAD"
+    ],
+    "rejected_approaches": [],
+    "open_threads": [],
+    "key_artifacts": [
+      ".github/workflows/memex-check.yml"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/memex-check.yml` that runs on every PR targeting `main`
- Fails the check if no new `.memex/nodes/*.json` file was added
- Fails if `.memex/graph.json` was not modified
- Fails if any new node UUID is not referenced in `graph.json` (as `root_id` or in `edges`)

## How it works

Three checks run in a single shell step against a three-dot diff of the PR branch vs the base:

1. At least one file was added under `.memex/nodes/`
2. `.memex/graph.json` was modified
3. Each new node's UUID appears in `graph.json` as either `root_id` or an edge endpoint — covers both root nodes (no parent) and regular parented nodes

## Test plan

- [ ] Open a PR without a memex node → check fails with "No new memex node found"
- [ ] Open a PR with a node file but unchanged `graph.json` → check fails on step 2
- [ ] Open a normal PR following the CLAUDE.md workflow → all checks pass
- [ ] Confirm the check appears in the PR checks UI as `Verify memex node created`