### PR TITLE
docs: align CLAUDE.md structure with startrail's

### DIFF
--- a/.memex/graph.json
+++ b/.memex/graph.json
@@ -81,6 +81,10 @@
     {
       "from": "269bfac9-e21c-42a3-8ed0-6bbc5ead6a17",
       "to": "5a17fac4-c62e-4db5-bf10-183486bc4b31"
+    },
+    {
+      "from": "269bfac9-e21c-42a3-8ed0-6bbc5ead6a17",
+      "to": "1d566d00-399a-4447-aa27-1210f5acdd45"
     }
   ]
 }

--- a/.memex/nodes/1d566d00-399a-4447-aa27-1210f5acdd45.json
+++ b/.memex/nodes/1d566d00-399a-4447-aa27-1210f5acdd45.json
@@ -1,0 +1,31 @@
+{
+  "id": "1d566d00-399a-4447-aa27-1210f5acdd45",
+  "parent_ids": [
+    "269bfac9-e21c-42a3-8ed0-6bbc5ead6a17"
+  ],
+  "git_ref": "docs/claude-md-structure-alignment (b91fa95f)",
+  "created_at": "2026-04-20T05:44:30.435866Z",
+  "updated_at": "2026-04-20T05:45:44.103061Z",
+  "summary": {
+    "goal": "Restructure CLAUDE.md to mirror startrail's layout — add Stack/Scripts tables, promote Key design decisions to a top-level section, and enrich workflow steps 5/7/8 with reflection prompts for rejected/open-thread, explicit state.json rationale, and a PR description template",
+    "decisions": [
+      "Adopted startrail's CLAUDE.md structure (Stack / Key design decisions / Structure / Where tracked / Scripts / Workflow / Doc hygiene) because the two projects should feel like siblings to an agent; a consistent shape reduces the cognitive load when switching between them",
+      "Kept memex-specific content under each heading (Rust stack, cargo scripts, GraphStore I/O boundary, state.json vs graph.json rationale) rather than copying startrail's Next.js specifics — the structure transfers, the content does not",
+      "Enriched workflow step 5 with the reflection prompts startrail uses for --rejected and --open-thread; under-used fields in this repo, so the prompt itself has leverage",
+      "Added a PR description template (Summary + Test plan) to step 8 to match recent PR style and remove template-drafting overhead for future agents"
+    ],
+    "rejected_approaches": [
+      {
+        "description": "Port startrail's CLAUDE.md verbatim, minus the Next.js bits",
+        "reason": "Would have introduced concepts that do not apply here (Vercel hosting, NextAuth, Drizzle). Structure-only port keeps every line load-bearing for memex."
+      }
+    ],
+    "open_threads": [],
+    "key_artifacts": [
+      "CLAUDE.md"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,58 +2,34 @@
 
 ## What this project is
 
-`memex` is a CLI tool that organizes LLM-assisted development into a versioned DAG of conversation nodes. It is a **storage and navigation layer**.
+`memex` is a CLI tool that organizes LLM-assisted development into a versioned DAG of conversation nodes. It is a **storage and navigation layer** — the graph lives on disk under `.memex/`, and git is the transport that carries it between machines and collaborators.
 
-## Development workflow
+## Stack
 
-> **IMPORTANT:** For any code change, bug fix, or new feature — always execute the steps below without being explicitly asked. Do not write any code before completing steps 1–3 (find parent node, branch, create node).
+| Layer       | Choice                                 |
+| ----------- | -------------------------------------- |
+| Language    | Rust 2021 edition                      |
+| CLI parsing | `clap` v4 (derive)                     |
+| Serde       | `serde` + `serde_json` + `toml`        |
+| IDs / time  | `uuid` v4, `chrono`                    |
+| Errors      | `anyhow`                               |
+| Editor I/O  | `tempfile` + `$EDITOR` subprocess      |
+| Git         | `git` subprocess (no libgit2)          |
+| Testing     | built-in `cargo test` + `assert_cmd`   |
 
-This project tracks its own development using `memex`. Follow this pattern for every feature or fix:
+## Key design decisions
 
-1. **Find a parent node** - Choose the parent based on what your work *depends on*, not just what is most recent:
-   - `memex graph` - visualize the current DAG to see branching structure
-   - `memex node list` - shows all nodes with IDs, parent IDs, statuses, git refs, and one-line goals
-   - `memex search <keyword>` - full-text search across node summaries; use domain terms (e.g. `config`, `search`, `rename`) to surface related prior work
-   - If your work extends a specific prior feature, attach to that feature's node even if it isn't the tip
-   - If your work is independent of recent changes, find the most recent resolved node whose scope your work builds on
-   - If your work depends directly on what just landed, attach to the active node (the linear case, correct when the dependency is real)
-   - e.g. adding tests for the search command → parent is the node that implemented search, not documentation or cleanup nodes that landed after it
-   - e.g. fixing a crash in `node edit` → parent is the node that introduced `node edit`, not whatever resolved most recently
-   - e.g. adding a new `memex export` command → find the most recent node that touched the CLI structure; skip unrelated docs or refactors that followed it
+**One JSON file per node.** `.memex/nodes/<uuid>.json` keeps diffs human-readable and merge-friendly; avoid bundling multiple nodes into a single file.
 
-2. **Branch** - `git checkout -b <type>/<name>` from `main`
+**`graph.json` is shared, `state.json` is per-developer.** `graph.json` holds edges + root pointer and is committed. `state.json` holds the active-node pointer for the current developer and is `.gitignore`'d — committing it creates guaranteed merge conflicts.
 
-3. **Node** - `memex node create --parent <parent-id> --goal "<your goal here>"` before writing any code. Use the real goal if you already know it; a short placeholder is fine when the scope is still uncertain.
+**Git via subprocess.** Integration shells out to `git` rather than linking libgit2. Keeps the dependency footprint small and matches user expectations (same git binary, same config, same auth).
 
-4. **Implement** the feature
+**All file I/O routes through `GraphStore`.** Commands in `src/commands/` should not read or write files directly — go through `store.rs` so tests can substitute a temp dir and behavior stays consistent.
 
-5. **Summarize** - Record decisions, artifacts, and rejected approaches incrementally as you work. Write these from observations during implementation, not from post-hoc reflection:
-   ```
-   memex node edit --decision "chose X over Y because Z"
-   memex node edit --artifact "path/to/key/file.rs"
-   memex node edit --open-thread "question to revisit later"
-   memex node edit --rejected $'description = "Alternative approach"\nreason = "Why rejected"'
-   memex node edit --goal "Updated goal if scope changed"
-   ```
-   Each flag appends to (or overwrites for `--goal`) the current node without touching other fields.
-   Use `--summary` only for a full bulk replacement (e.g. bootstrapping from a plan).
+**TOML for editor input, JSON for storage.** `memex node edit` opens a TOML temp file (friendlier to hand-edit); the store persists JSON. The asymmetry is intentional.
 
-6. **Resolve or abandon** - `memex node resolve` when the work is complete. If the task is superseded or turns out to be the wrong approach, use `memex node abandon` with a note in the summary explaining why.
-
-7. **Commit** - Commit source changes and `.memex/graph.json` + `.memex/nodes/` together. Never commit `.memex/state.json`. Documentation updates (CLAUDE.md, README.md) go in a separate commit so the source diff and doc diff are independently reviewable.
-
-8. **Push** and open a PR
-
-## Documentation hygiene
-
-After implementing any change, check whether it affects user-visible behavior, CLI output, or workflow guidance:
-
-- If **CLAUDE.md** describes the changed behavior (commands, output format, workflow steps), update it.
-- If **README.md** documents the changed command or output, update it.
-
-Always make documentation updates a **separate commit** from the source change.
-
-## Architecture
+## Project structure
 
 ```
 src/
@@ -68,9 +44,90 @@ src/
     graph.rs            - ASCII tree view
     context.rs          - context payload generation (markdown/xml/plain)
     search.rs           - full-text search across node summaries
+tests/
+  integration_tests.rs  - end-to-end CLI tests via assert_cmd
 ```
 
-Key design decisions:
-- One JSON file per node (`nodes/<uuid>.json`) for human-readable git diffs
-- `graph.json` holds edges + root pointer; `state.json` (untracked) holds active node
-- Git integration uses `git` subprocess, not libgit2, to keep the dependency footprint small
+## Where the work is tracked
+
+memex tracks its own development as memex nodes. There is no external issue tracker — the frontier lives in `.memex/`. Run `memex node list` to see current state; use `memex graph` to see branching. Old plans or design notes do not supersede the live graph.
+
+## Scripts
+
+| Command                                       | When to run                                              |
+| --------------------------------------------- | -------------------------------------------------------- |
+| `cargo build`                                 | Local build                                              |
+| `cargo run -- <args>`                         | Manual verification of CLI behavior                      |
+| `cargo test --all-targets`                    | Run unit + integration tests; what CI runs               |
+| `cargo fmt --all -- --check`                  | Formatting check (CI-gated)                              |
+| `cargo fmt --all`                             | Apply formatting                                         |
+| `cargo clippy --all-targets -- -D warnings`   | Lint (CI-gated, warnings are errors); run before PR      |
+
+CI (`.github/workflows/ci.yml`) runs fmt-check, clippy-with-deny-warnings, and the full test suite on every push and PR to `main`. Resolve a memex node only after all three pass locally.
+
+---
+
+## Development workflow
+
+> **IMPORTANT:** For any code change, bug fix, or new feature — always execute the steps below without being explicitly asked. Do not write any code before completing steps 1–3 (find parent node, branch, create node).
+
+This project tracks its own development using `memex`. Follow this pattern for every feature or fix:
+
+1. **Find a parent node** - Choose the parent based on what your work _depends on_, not just what is most recent:
+   - `memex graph` - visualize the current DAG to see branching structure
+   - `memex node list` - shows all nodes with IDs, parent IDs, statuses, git refs, and one-line goals
+   - `memex search <keyword>` - full-text search across node summaries; use domain terms (e.g. `config`, `search`, `rename`) to surface related prior work
+   - If your work extends a specific prior feature, attach to that feature's node even if it isn't the tip
+   - If your work is independent of recent changes, find the most recent resolved node whose scope your work builds on
+   - If your work depends directly on what just landed, attach to the active node (the linear case, correct when the dependency is real)
+   - e.g. adding tests for the search command → parent is the node that implemented search, not documentation or cleanup nodes that landed after it
+   - e.g. fixing a crash in `node edit` → parent is the node that introduced `node edit`, not whatever resolved most recently
+   - e.g. adding a new `memex export` command → find the most recent node that touched the CLI structure; skip unrelated docs or refactors that followed it
+
+2. **Branch** - `git checkout -b <type>/<name>` from `main` (e.g. `fix/node-edit-crash`, `feat/export-command`, `test/store-roundtrip`, `chore/audit-graph-parent-relationships`).
+
+3. **Node** - `memex node create --parent <parent-id> --goal "<your goal here>"` before writing any code. Use the real goal if you already know it; a short placeholder is fine when the scope is still uncertain.
+
+4. **Implement** the feature. Non-trivial changes to `src/store.rs`, `src/models.rs`, or any `src/commands/*.rs` should come with tests — prefer integration tests in `tests/integration_tests.rs` for CLI-visible behavior, inline `#[cfg(test)]` modules for pure logic.
+
+5. **Summarize** - Record as you go, not after. For every `--decision` you record, ask: _what alternative did I deliberately not take, and why?_ If there's an answer, that's a `--rejected`. Before resolving, ask: _what question did I defer, what caveat did I notice, what did I leave for later?_ Each one is an `--open-thread`. These two fields are under-used across the repo; using them gives future agents (and future-you) the context that decisions alone don't capture.
+
+   ```
+   memex node edit --decision "chose X over Y because Z"
+   memex node edit --artifact "path/to/key/file.rs"
+   memex node edit --open-thread "question to revisit later"
+   memex node edit --rejected $'description = "Alternative approach"\nreason = "Why rejected"'
+   memex node edit --goal "Updated goal if scope changed"
+   ```
+
+   Each flag appends to (or overwrites for `--goal`) the current node without touching other fields.
+   Use `--summary` only for a full bulk replacement (e.g. bootstrapping from a plan).
+
+6. **Resolve or abandon** - Run `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all-targets` locally; all three must pass. Then `memex node resolve` when the work is complete. If the task is superseded or turns out to be the wrong approach, use `memex node abandon` with a note in the summary explaining why.
+
+7. **Commit** - Commit source changes and `.memex/graph.json` + `.memex/nodes/` together — they describe the same unit of work. Never commit `.memex/state.json`: it's per-developer working-node state and will create merge conflicts. Documentation updates (CLAUDE.md, README.md) go in a separate commit so the source diff and doc diff are independently reviewable.
+
+8. **Push** and open a PR.
+
+   PR description template — match what recent PRs already do:
+
+   ```markdown
+   ## Summary
+
+   - 2–5 bullets: what changed and why
+
+   ## Test plan
+
+   - Checklist of verification steps (commands to run, expected output)
+   ```
+
+   Title ends with `(closes #N)` when the PR resolves an issue. Branch names follow `<type>/<name>` (e.g. `fix/node-edit-crash`, `chore/audit-graph-parent-relationships`).
+
+## Documentation hygiene
+
+After implementing any change, check whether it affects user-visible behavior, CLI output, or workflow guidance:
+
+- If **CLAUDE.md** describes the changed behavior (commands, output format, workflow steps), update it.
+- If **README.md** documents the changed command or output, update it.
+
+Always make documentation updates a **separate commit** from the source change.


### PR DESCRIPTION
## Summary

- Restructures CLAUDE.md to mirror startrail's section layout (Stack, Key design decisions, Structure, Where tracked, Scripts, Workflow, Doc hygiene) so an agent switching between the sibling repos finds the same shape.
- Promotes memex's design decisions to a top-level section and adds a Scripts table tying `cargo fmt`/`clippy`/`test` to the CI gate.
- Enriches workflow step 5 with the reflection prompts startrail uses for `--rejected` and `--open-thread`, makes step 7's rationale for never committing `state.json` explicit, and adds a PR description template to step 8.
- Docs-only change; no source files touched.