### PR TITLE
infra: add cargo audit to CI (closes #25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,12 @@ jobs:
         env:
           # /usr/bin/true exits 0 immediately — prevents any editor invocation from blocking CI
           EDITOR: true
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.memex/graph.json
+++ b/.memex/graph.json
@@ -93,6 +93,10 @@
     {
       "from": "af5774e3-d353-477c-93ea-8f465e62028e",
       "to": "27ed3dfa-d5c3-4b34-8b44-1f633e47d32f"
+    },
+    {
+      "from": "27ed3dfa-d5c3-4b34-8b44-1f633e47d32f",
+      "to": "074d970f-d6e3-4c42-aae5-7c73c3adcd80"
     }
   ]
 }

--- a/.memex/nodes/074d970f-d6e3-4c42-aae5-7c73c3adcd80.json
+++ b/.memex/nodes/074d970f-d6e3-4c42-aae5-7c73c3adcd80.json
@@ -1,0 +1,29 @@
+{
+  "id": "074d970f-d6e3-4c42-aae5-7c73c3adcd80",
+  "parent_ids": [
+    "27ed3dfa-d5c3-4b34-8b44-1f633e47d32f"
+  ],
+  "git_ref": "infra/cargo-audit-ci (2e442140)",
+  "created_at": "2026-05-03T14:51:25.692514Z",
+  "updated_at": "2026-05-03T14:52:15.982525Z",
+  "summary": {
+    "goal": "Add cargo audit step to CI to flag known-vulnerable dependencies before merge",
+    "decisions": [
+      "used rustsec/audit-check@v2 action as a separate parallel job rather than a step in the test job — cleaner separation and runs concurrently with the test suite",
+      "separate job over cargo install in test job to avoid slowing down the main test suite with a slow install step"
+    ],
+    "rejected_approaches": [
+      {
+        "description": "cargo install cargo-audit in test job",
+        "reason": "bloats the test job with a slow install; separate job runs in parallel and keeps concerns separated"
+      }
+    ],
+    "open_threads": [],
+    "key_artifacts": [
+      ".github/workflows/ci.yml"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}


### PR DESCRIPTION
## Summary

- Adds a `Security Audit` job to `.github/workflows/ci.yml` using `rustsec/audit-check@v2`
- Runs in parallel with the existing `Test Suite` job so it doesn't slow down the build
- Annotates PRs directly when a known-vulnerable dependency is detected
- Closes #25

## Test plan

- [x] CI passes on this PR (both `Test Suite` and `Security Audit` jobs green)
- [x] Verify the `Security Audit` job appears in the GitHub Actions run for this PR