### PR TITLE
infra: add macOS and Windows to CI test matrix (closes #30)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,11 @@ env:
 
 jobs:
   test:
-    name: Test Suite
-    runs-on: ubuntu-latest
+    name: Test Suite (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -33,15 +36,18 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: cargo fmt --check
+        if: matrix.os == 'ubuntu-latest'
         run: cargo fmt --all -- --check
 
       - name: cargo clippy
+        if: matrix.os == 'ubuntu-latest'
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: cargo test
         run: cargo test --all-targets
         env:
-          # /usr/bin/true exits 0 immediately — prevents any editor invocation from blocking CI
+          # exits 0 immediately — prevents any editor invocation from blocking CI
+          # on Windows, Git for Windows provides true.exe on PATH
           EDITOR: true
 
   audit:

--- a/.memex/graph.json
+++ b/.memex/graph.json
@@ -97,6 +97,10 @@
     {
       "from": "27ed3dfa-d5c3-4b34-8b44-1f633e47d32f",
       "to": "074d970f-d6e3-4c42-aae5-7c73c3adcd80"
+    },
+    {
+      "from": "074d970f-d6e3-4c42-aae5-7c73c3adcd80",
+      "to": "b253e1d1-9fc1-4509-aeb3-0221bba8a1cb"
     }
   ]
 }

--- a/.memex/nodes/b253e1d1-9fc1-4509-aeb3-0221bba8a1cb.json
+++ b/.memex/nodes/b253e1d1-9fc1-4509-aeb3-0221bba8a1cb.json
@@ -1,0 +1,27 @@
+{
+  "id": "b253e1d1-9fc1-4509-aeb3-0221bba8a1cb",
+  "parent_ids": [
+    "074d970f-d6e3-4c42-aae5-7c73c3adcd80"
+  ],
+  "git_ref": "infra/ci-matrix-os (3d286bd4)",
+  "created_at": "2026-05-03T15:03:59.083521Z",
+  "updated_at": "2026-05-03T15:08:09.832675Z",
+  "summary": {
+    "goal": "Add OS matrix to CI for macOS and Windows test coverage (closes #30)",
+    "decisions": [
+      "Run cargo fmt --check and cargo clippy only on ubuntu-latest; these are platform-independent linters so running them 3x adds noise with no signal",
+      "Keep EDITOR: true for all OSes; Git for Windows provides true.exe on PATH for Windows runners, and no integration test actually invokes the editor path"
+    ],
+    "rejected_approaches": [
+      {
+        "description": "Run fmt/clippy on all three OSes",
+        "reason": "Redundant — formatting and linting are platform-independent; triples CI time with no benefit"
+      }
+    ],
+    "open_threads": [],
+    "key_artifacts": []
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}


### PR DESCRIPTION
## Summary

- Adds `strategy.matrix.os` to the test job with `ubuntu-latest`, `macos-latest`, and `windows-latest`
- `cargo fmt --check` and `cargo clippy` run only on `ubuntu-latest` — these are platform-independent linters; tripling them adds CI time with no signal
- `cargo test --all-targets` runs on all three OSes
- `EDITOR: true` stays as-is; Git for Windows provides `true.exe` on PATH for Windows runners, and no integration test actually invokes the editor

## Test plan

- [x] CI passes on all three matrix legs (ubuntu, macos, windows)
- [x] fmt/clippy steps are skipped on macOS and Windows legs
- [x] All 32 tests pass on the Linux leg locally (`cargo test --all-targets`)