### PR TITLE
fix: surface orphaned nodes in context generation (closes #27)

### DIFF
--- a/.memex/graph.json
+++ b/.memex/graph.json
@@ -97,6 +97,10 @@
     {
       "from": "27ed3dfa-d5c3-4b34-8b44-1f633e47d32f",
       "to": "074d970f-d6e3-4c42-aae5-7c73c3adcd80"
+    },
+    {
+      "from": "9f869ab8-4aa9-499c-b316-a3c563407906",
+      "to": "f5184c9b-f9c4-41ca-ab86-b90d23bc4efe"
     }
   ]
 }

--- a/.memex/nodes/f5184c9b-f9c4-41ca-ab86-b90d23bc4efe.json
+++ b/.memex/nodes/f5184c9b-f9c4-41ca-ab86-b90d23bc4efe.json
@@ -1,0 +1,28 @@
+{
+  "id": "f5184c9b-f9c4-41ca-ab86-b90d23bc4efe",
+  "parent_ids": [
+    "9f869ab8-4aa9-499c-b316-a3c563407906"
+  ],
+  "git_ref": "fix/context-orphaned-node-warning (3d286bd4)",
+  "created_at": "2026-05-03T15:16:34.820372Z",
+  "updated_at": "2026-05-03T15:18:07.918541Z",
+  "summary": {
+    "goal": "Fix find_path to return None for unreachable nodes and emit a stderr warning instead of silently returning a singleton path",
+    "decisions": [
+      "find_path now returns None for unreachable nodes; run() emits a stderr warning and falls back to vec![target] so context output still works for orphaned nodes"
+    ],
+    "rejected_approaches": [
+      {
+        "description": "Return an error from run() when node is unreachable",
+        "reason": "Would break UX for users with corrupted graphs — a warning with degraded output is preferable to a hard failure"
+      }
+    ],
+    "open_threads": [],
+    "key_artifacts": [
+      "src/commands/context.rs"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -36,8 +36,16 @@ pub fn run(id: Option<&str>, format: OutputFormat, depth: usize) -> Result<()> {
         .root_id
         .ok_or_else(|| anyhow::anyhow!("Graph has no root node"))?;
 
-    let path = find_path(root_id, node_id, &node_map)
-        .ok_or_else(|| anyhow::anyhow!("Could not find path from root to node {}", node_id))?;
+    let path = match find_path(root_id, node_id, &node_map) {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "warning: node {} is not reachable from the graph root — ancestor context will be incomplete",
+                &node_id.to_string()[..8]
+            );
+            vec![node_id]
+        }
+    };
 
     let path = trim_path(path, depth);
 
@@ -102,8 +110,7 @@ pub(crate) fn find_path(
         }
     }
 
-    // If not found via parent traversal, just return [target] as fallback
-    Some(vec![target])
+    None
 }
 
 fn generate_markdown(
@@ -501,15 +508,14 @@ mod tests {
     }
 
     #[test]
-    fn find_path_unreachable_target_returns_singleton() {
+    fn find_path_unreachable_target_returns_none() {
         let start = Uuid::new_v4();
         let target = Uuid::new_v4();
         let n_start = make_node(start, vec![]);
         let n_target = make_node(target, vec![]); // no relationship to start
         let nodes = vec![n_start, n_target];
         let map = node_map(&nodes);
-        // Contract: fallback returns Some([target]) when target is not reachable from start
-        assert_eq!(find_path(start, target, &map), Some(vec![target]));
+        assert_eq!(find_path(start, target, &map), None);
     }
 
     // --- trim_path ---


### PR DESCRIPTION
## Summary

- `find_path` in `src/commands/context.rs` previously returned `Some(vec![target])` as a silent fallback when a node was unreachable from the graph root, masking inconsistent graph state
- `find_path` now returns `None` for unreachable nodes, making the false-reachability contract impossible
- The `run()` caller emits a `warning:` line to stderr when `None` is returned and falls back to the singleton path, so context output still works while the inconsistency is visible

## Test plan

- `cargo test --all-targets` — all 89 tests pass, including renamed `find_path_unreachable_target_returns_none` which now asserts `None`
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Manual: create a node with no parent relationship to root and run `memex context <id>` — confirms warning is printed to stderr and output is still generated