### PR TITLE
feat: add confirmation prompt to node resolve and abandon (closes #26)

### DIFF
--- a/.memex/graph.json
+++ b/.memex/graph.json
@@ -105,6 +105,10 @@
     {
       "from": "074d970f-d6e3-4c42-aae5-7c73c3adcd80",
       "to": "b253e1d1-9fc1-4509-aeb3-0221bba8a1cb"
+    },
+    {
+      "from": "f5184c9b-f9c4-41ca-ab86-b90d23bc4efe",
+      "to": "c0d9b8aa-d7ce-485e-a02f-468b3666e35e"
     }
   ]
 }

--- a/.memex/nodes/c0d9b8aa-d7ce-485e-a02f-468b3666e35e.json
+++ b/.memex/nodes/c0d9b8aa-d7ce-485e-a02f-468b3666e35e.json
@@ -1,0 +1,31 @@
+{
+  "id": "c0d9b8aa-d7ce-485e-a02f-468b3666e35e",
+  "parent_ids": [
+    "f5184c9b-f9c4-41ca-ab86-b90d23bc4efe"
+  ],
+  "git_ref": "feat/confirm-destructive-ops (7356024f)",
+  "created_at": "2026-05-03T16:06:02.021490Z",
+  "updated_at": "2026-05-03T16:12:40.078198Z",
+  "summary": {
+    "goal": "Add confirmation prompt to abandon/resolve to prevent accidental destructive status changes (closes #26)",
+    "decisions": [
+      "Added --force/-y flag to resolve and abandon; reopen always skips prompt since it is non-destructive",
+      "Used std::io::IsTerminal on stdin to gate the prompt; non-TTY contexts (CI, pipes) skip prompt automatically without needing --force"
+    ],
+    "rejected_approaches": [
+      {
+        "description": "Adding confirmation to reopen as well",
+        "reason": "Reopen is not destructive — it recovers state — so prompting would add friction with no safety benefit"
+      }
+    ],
+    "open_threads": [],
+    "key_artifacts": [
+      "src/main.rs",
+      "src/commands/node.rs",
+      "tests/integration_tests.rs"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ List all nodes with IDs, parent IDs, status, git ref, and goal.
 
 Transition a node's status between Active, Resolved, and Abandoned.
 
+`resolve` and `abandon` prompt for confirmation when run in an interactive terminal:
+
+```
+Resolve node abc12345 "Add user authentication"? [y/N]
+```
+
+| Flag | Description |
+|---|---|
+| `--force` / `-y` | Skip the confirmation prompt (for scripts and CI) |
+
+Non-interactive contexts (pipes, CI) skip the prompt automatically.
+
 ### `memex context [id]`
 
 Generate a context payload. Walks the ancestor chain and formats it for pasting into a new conversation.

--- a/src/commands/node.rs
+++ b/src/commands/node.rs
@@ -1,3 +1,5 @@
+use std::io::{self, IsTerminal, Write};
+
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
 
@@ -192,15 +194,15 @@ pub fn list() -> Result<()> {
     Ok(())
 }
 
-pub fn set_status(id: Option<&str>, status: NodeStatus) -> Result<()> {
+pub fn set_status(id: Option<&str>, status: NodeStatus, force: bool) -> Result<()> {
     let store = GraphStore::open_from_cwd()?;
     let node_id = store.resolve_node_id(id)?;
     let mut node = store.load_node(node_id)?;
 
     let verb = match &status {
-        NodeStatus::Resolved => "resolved",
-        NodeStatus::Abandoned => "abandoned",
-        NodeStatus::Active => "reopened",
+        NodeStatus::Resolved => "resolve",
+        NodeStatus::Abandoned => "abandon",
+        NodeStatus::Active => "reopen",
     };
 
     // Validate transitions
@@ -217,12 +219,48 @@ pub fn set_status(id: Option<&str>, status: NodeStatus) -> Result<()> {
         _ => {}
     }
 
+    if !force && io::stdin().is_terminal() {
+        let goal_preview: String = node.summary.goal.chars().take(60).collect();
+        let goal_preview = if node.summary.goal.len() > 60 {
+            format!("{}…", goal_preview)
+        } else {
+            goal_preview
+        };
+        eprint!(
+            "{} node {} \"{}\"? [y/N] ",
+            capitalize(verb),
+            node.short_id(),
+            goal_preview
+        );
+        io::stderr().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        if !matches!(input.trim().to_lowercase().as_str(), "y" | "yes") {
+            bail!("Aborted.");
+        }
+    }
+
+    let past_verb = match &status {
+        NodeStatus::Resolved => "resolved",
+        NodeStatus::Abandoned => "abandoned",
+        NodeStatus::Active => "reopened",
+    };
+
     node.status = status;
     node.updated_at = Utc::now();
     store.save_node(&node)?;
 
-    println!("Node {} {}.", node.short_id(), verb);
+    println!("Node {} {}.", node.short_id(), past_verb);
     Ok(())
+}
+
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
 }
 
 fn print_node_detail(node: &ConversationNode, is_active: bool) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,12 +123,20 @@ enum NodeCommands {
     Resolve {
         /// Node ID (defaults to active node)
         id: Option<String>,
+
+        /// Skip confirmation prompt
+        #[arg(long, short = 'y')]
+        force: bool,
     },
 
     /// Mark a node as abandoned
     Abandon {
         /// Node ID (defaults to active node)
         id: Option<String>,
+
+        /// Skip confirmation prompt
+        #[arg(long, short = 'y')]
+        force: bool,
     },
 
     /// Reopen a resolved or abandoned node (set back to Active)
@@ -187,14 +195,14 @@ fn run(cli: Cli) -> Result<()> {
             ),
             NodeCommands::Show { id } => commands::node::show(id.as_deref()),
             NodeCommands::List => commands::node::list(),
-            NodeCommands::Resolve { id } => {
-                commands::node::set_status(id.as_deref(), NodeStatus::Resolved)
+            NodeCommands::Resolve { id, force } => {
+                commands::node::set_status(id.as_deref(), NodeStatus::Resolved, force)
             }
-            NodeCommands::Abandon { id } => {
-                commands::node::set_status(id.as_deref(), NodeStatus::Abandoned)
+            NodeCommands::Abandon { id, force } => {
+                commands::node::set_status(id.as_deref(), NodeStatus::Abandoned, force)
             }
             NodeCommands::Reopen { id } => {
-                commands::node::set_status(id.as_deref(), NodeStatus::Active)
+                commands::node::set_status(id.as_deref(), NodeStatus::Active, true)
             }
         },
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -378,6 +378,68 @@ fn node_reopen_already_active_errors() {
         .stderr(predicate::str::contains("already active").or(predicate::str::contains("already")));
 }
 
+// ─── Node resolve/abandon --force ────────────────────────────────────────────
+
+#[test]
+fn node_resolve_with_force_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Task to force-resolve");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "resolve", "--force"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Resolved"));
+}
+
+#[test]
+fn node_resolve_with_short_force_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Task to force-resolve short");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "resolve", "-y"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Resolved"));
+}
+
+#[test]
+fn node_abandon_with_force_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Task to force-abandon");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "abandon", "--force"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Abandoned"));
+}
+
 // ─── Node show / list ────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- `memex node resolve` and `memex node abandon` now prompt for confirmation when stdin is a terminal, preventing accidental destructive status changes
- Prompt format: `Resolve node abc12345 "goal preview…"? [y/N]` printed to stderr
- `--force` / `-y` flag bypasses the prompt for scripted or CI use
- Non-TTY contexts (pipes, CI) skip the prompt automatically — existing scripts and CI jobs require no changes
- `reopen` is intentionally unchanged — recovering state is non-destructive

## Test plan

- [x] `cargo test --all-targets` — all 35 integration tests and 57 unit tests pass
- [x] `cargo fmt --all -- --check` — no formatting issues
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] Manual: `memex node resolve` in a terminal prompts for confirmation; `n` aborts
- [x] Manual: `memex node resolve --force` skips prompt and resolves immediately
- [x] Manual: `memex node resolve -y` skips prompt (short flag)
- [x] Manual: `memex node abandon --force` skips prompt and abandons immediately