### PR TITLE
fix: remove graph.edges dual source of truth (closes #28)

### DIFF
--- a/.memex/graph.json
+++ b/.memex/graph.json
@@ -109,6 +109,10 @@
     {
       "from": "f5184c9b-f9c4-41ca-ab86-b90d23bc4efe",
       "to": "c0d9b8aa-d7ce-485e-a02f-468b3666e35e"
+    },
+    {
+      "from": "c0d9b8aa-d7ce-485e-a02f-468b3666e35e",
+      "to": "b95077e3-0e5f-4dc8-ae2d-3511ea3e076e"
     }
   ]
 }

--- a/.memex/nodes/b95077e3-0e5f-4dc8-ae2d-3511ea3e076e.json
+++ b/.memex/nodes/b95077e3-0e5f-4dc8-ae2d-3511ea3e076e.json
@@ -1,0 +1,31 @@
+{
+  "id": "b95077e3-0e5f-4dc8-ae2d-3511ea3e076e",
+  "parent_ids": [
+    "f5184c9b-f9c4-41ca-ab86-b90d23bc4efe"
+  ],
+  "git_ref": "fix/remove-graph-edges-dual-source (d5a8c4ab)",
+  "created_at": "2026-05-03T16:31:31.334449Z",
+  "updated_at": "2026-05-03T16:36:29.361935Z",
+  "summary": {
+    "goal": "Remove graph.edges dual representation: derive children from node.parent_ids (closes #28)",
+    "decisions": [
+      "Drop graph.edges entirely; derive children map by inverting node.parent_ids at load time in graph.rs view command"
+    ],
+    "rejected_approaches": [
+      {
+        "description": "Add GraphStore::check_integrity() and call it on load",
+        "reason": "Two representations are still maintained; integrity checks only catch divergence after the fact. Dropping edges entirely eliminates the dual source of truth rather than papering over it."
+      }
+    ],
+    "open_threads": [],
+    "key_artifacts": [
+      "src/models.rs",
+      "src/commands/graph.rs",
+      "src/commands/node.rs",
+      "src/store.rs"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/src/commands/graph.rs
+++ b/src/commands/graph.rs
@@ -19,10 +19,12 @@ pub fn view() -> Result<()> {
 
     let node_map: HashMap<Uuid, &ConversationNode> = nodes.iter().map(|n| (n.id, n)).collect();
 
-    // Build children map from graph edges
+    // Build children map by inverting each node's parent_ids
     let mut children: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
-    for edge in &graph.edges {
-        children.entry(edge.from).or_default().push(edge.to);
+    for node in &nodes {
+        for &parent_id in &node.parent_ids {
+            children.entry(parent_id).or_default().push(node.id);
+        }
     }
 
     // Find roots: nodes with no parents (or the designated root_id first)

--- a/src/commands/node.rs
+++ b/src/commands/node.rs
@@ -15,7 +15,6 @@ pub fn create(
     goal: Option<&str>,
 ) -> Result<()> {
     let store = GraphStore::open_from_cwd()?;
-    let mut graph = store.load_graph()?;
 
     // Resolve parent ID
     let parent_id = if let Some(p) = parent {
@@ -50,18 +49,12 @@ pub fn create(
         editor::edit_node_summary(None)?
     };
 
-    let mut node = ConversationNode::new(parent_ids.clone(), resolved_git_ref, tags.to_vec());
+    let mut node = ConversationNode::new(parent_ids, resolved_git_ref, tags.to_vec());
     node.summary = summary;
 
     let node_id = node.id;
 
-    // Add edges to graph
-    for pid in &parent_ids {
-        graph.add_edge(*pid, node_id);
-    }
-
     store.save_node(&node)?;
-    store.save_graph(&graph)?;
     store.set_active_id(node_id)?;
 
     println!("Created node: {}", node_id);

--- a/src/models.rs
+++ b/src/models.rs
@@ -78,16 +78,9 @@ impl ConversationNode {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Edge {
-    pub from: Uuid,
-    pub to: Uuid,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Graph {
     pub version: String,
     pub root_id: Option<Uuid>,
-    pub edges: Vec<Edge>,
 }
 
 impl Graph {
@@ -95,12 +88,7 @@ impl Graph {
         Graph {
             version: "1".to_string(),
             root_id: None,
-            edges: Vec::new(),
         }
-    }
-
-    pub fn add_edge(&mut self, from: Uuid, to: Uuid) {
-        self.edges.push(Edge { from, to });
     }
 }
 
@@ -259,27 +247,6 @@ mod tests {
     }
 
     #[test]
-    fn graph_add_edge() {
-        let mut g = Graph::new();
-        let a = Uuid::new_v4();
-        let b = Uuid::new_v4();
-        g.add_edge(a, b);
-        assert_eq!(g.edges.len(), 1);
-        assert_eq!(g.edges[0].from, a);
-        assert_eq!(g.edges[0].to, b);
-    }
-
-    #[test]
-    fn graph_add_multiple_edges() {
-        let mut g = Graph::new();
-        let (a, b, c) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
-        g.add_edge(a, b);
-        g.add_edge(a, c);
-        g.add_edge(b, c);
-        assert_eq!(g.edges.len(), 3);
-    }
-
-    #[test]
     fn node_summary_default_is_empty() {
         let s = NodeSummary::default();
         assert!(s.goal.is_empty());
@@ -362,18 +329,24 @@ mod tests {
     fn graph_json_roundtrip() {
         let mut g = Graph::new();
         let root = Uuid::new_v4();
-        let child = Uuid::new_v4();
         g.root_id = Some(root);
-        g.add_edge(root, child);
-        g.add_edge(child, Uuid::new_v4());
 
         let json = serde_json::to_string(&g).unwrap();
         let back: Graph = serde_json::from_str(&json).unwrap();
 
         assert_eq!(back.root_id, Some(root));
-        assert_eq!(back.edges.len(), 2);
-        assert_eq!(back.edges[0].from, root);
-        assert_eq!(back.edges[0].to, child);
+    }
+
+    #[test]
+    fn graph_json_roundtrip_ignores_legacy_edges() {
+        let root = Uuid::new_v4();
+        let child = Uuid::new_v4();
+        // Simulate a graph.json written by an older version that included edges
+        let legacy = format!(
+            r#"{{"version":"1","root_id":"{root}","edges":[{{"from":"{root}","to":"{child}"}}]}}"#
+        );
+        let g: Graph = serde_json::from_str(&legacy).unwrap();
+        assert_eq!(g.root_id, Some(root));
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -292,18 +292,12 @@ mod tests {
         let (_tmp, store) = make_store();
         let mut g = Graph::new();
         let root = Uuid::new_v4();
-        let child = Uuid::new_v4();
         g.root_id = Some(root);
-        g.add_edge(root, child);
-        g.add_edge(child, Uuid::new_v4());
 
         store.save_graph(&g).unwrap();
         let loaded = store.load_graph().unwrap();
 
         assert_eq!(loaded.root_id, Some(root));
-        assert_eq!(loaded.edges.len(), 2);
-        assert_eq!(loaded.edges[0].from, root);
-        assert_eq!(loaded.edges[0].to, child);
     }
 
     #[test]
@@ -312,7 +306,6 @@ mod tests {
         // graph.json was not written during initialize()
         let g = store.load_graph().unwrap();
         assert!(g.root_id.is_none());
-        assert!(g.edges.is_empty());
     }
 
     // --- Node I/O ---


### PR DESCRIPTION
## Summary

- Removed `Edge` struct and `edges: Vec<Edge>` from `Graph` — the field was redundant with `node.parent_ids`
- `graph view` now builds its children map by inverting `node.parent_ids` at load time, eliminating the split where roots came from `parent_ids` but children came from `graph.edges`
- `node create` no longer writes to `graph.json` (no edges to persist); graph is only written at `init` time to set `root_id`
- Added a `graph_json_roundtrip_ignores_legacy_edges` test to confirm existing `graph.json` files with the old `edges` field are gracefully ignored by serde

## Test plan

- `cargo test --all-targets` — all 91 tests pass (2 new: `graph_json_roundtrip` updated, `graph_json_roundtrip_ignores_legacy_edges` added)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo run -- graph view` confirms the tree renders correctly from `parent_ids` alone