### PR TITLE
feat: add Claude Code plugin shipping a memex workflow skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "memex",
+  "owner": {
+    "name": "Maximiliano Rios",
+    "email": "max@maxrios.dev"
+  },
+  "metadata": {
+    "description": "Plugins shipped alongside the memex CLI.",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "memex",
+      "description": "Workflow skill for memex-enabled repositories — teaches autonomous agents how to track development as nodes in the .memex/ DAG.",
+      "source": "./claude-plugin"
+    }
+  ]
+}

--- a/.memex/nodes/f73e3f12-9465-477d-a79b-4395ec6ceaff.json
+++ b/.memex/nodes/f73e3f12-9465-477d-a79b-4395ec6ceaff.json
@@ -1,0 +1,48 @@
+{
+  "id": "f73e3f12-9465-477d-a79b-4395ec6ceaff",
+  "parent_ids": [
+    "bbb06973-3c59-4a14-86d1-37dc2b971225"
+  ],
+  "git_ref": "feat/claude-plugin (f3f9081b)",
+  "created_at": "2026-05-12T02:15:03.147393Z",
+  "updated_at": "2026-05-12T02:35:30.420313Z",
+  "summary": {
+    "goal": "Ship a Claude plugin (claude-plugin/) bundling a single 'memex' skill that externalizes the AGENTS.md workflow for autonomous agents working in memex-enabled repos outside this one",
+    "decisions": [
+      "Co-locate the plugin in the memex repo at claude-plugin/, versioned in lockstep with the CLI. Any PR that changes a subcommand or flag must update SKILL.md in the same diff — co-location forces this, separate repo would allow silent drift.",
+      "Ship a single skill (no slash commands, no hooks, no MCP server). Skill-only fits the autonomous-agent use case; slash commands are ergonomic shortcuts for humans-in-the-loop and were explicitly out of scope.",
+      "Skill description carries both implicit ('.memex/ directory present, about to make a code change') and explicit ('user mentions memex, nodes, tracked work') triggers. Implicit-only would miss user-initiated invocations; explicit-only would miss the agentic happy path.",
+      "Promote 'memex context --format xml' to the orientation step at the top of the workflow, ahead of list/show/graph. It's the only CLI command that delivers pre-shaped ancestor context in a single call; chaining is the wasteful alternative.",
+      "Make the memex repo itself a marketplace via .claude-plugin/marketplace.json at the root, with a single entry pointing at claude-plugin/. Without a marketplace there is no install path, so no way to dogfood the skill before shipping."
+    ],
+    "rejected_approaches": [
+      {
+        "description": "Put the plugin in a separate repository for independent release cadence and plugin-discovery cleanliness",
+        "reason": "The skill describes the CLI surface; a separate repo would let the skill drift silently as flags and subcommands change. Same-repo forces every CLI-changing PR to update SKILL.md in the same diff. Split later via git subtree if the plugin grows adapters for other agents."
+      },
+      {
+        "description": "Ship slash commands like /memex-start and /memex-resolve alongside the skill",
+        "reason": "User explicitly chose skill-only for the autonomous-agent use case. Slash commands are an ergonomic layer for humans driving Claude Code interactively; they would not help an autonomous agent already capable of invoking the CLI directly. Add later if a human-in-the-loop workflow emerges."
+      },
+      {
+        "description": "Hard-pick --format xml and --depth N defaults inside the skill body",
+        "reason": "Right values depend on graph shape, which the agent can read from `memex graph view`. The skill should expose the levers and let the model choose, not prescribe values that may be wrong for the target graph."
+      }
+    ],
+    "open_threads": [
+      "AGENTS.md still contains the full 'how to use memex' workflow that the skill now duplicates. Decide whether to slim AGENTS.md to just memex-self-development details (scripts, project structure, Rust conventions) and let the skill carry the workflow — or keep both as belt-and-suspenders. Out of scope for this PR.",
+      "CI does not validate the skill's example invocations against the actual memex binary. A flag rename in main.rs would not fail CI even though it silently breaks SKILL.md. Worth adding a smoke test that exercises each command form referenced in SKILL.md.",
+      "Plugin is installable from a local checkout (claude plugin add ./claude-plugin) but is not published to any marketplace. Publication path (claude-plugins-official marketplace? a memex-owned marketplace? plain git URL?) is undecided.",
+      "Skill verifies the CLI is present via 'memex --version' but does not parse the version. If the CLI surface diverges across versions, the skill cannot adapt; right now it implicitly assumes the latest. Worth revisiting once the CLI hits 1.0 and version-aware behavior matters."
+    ],
+    "key_artifacts": [
+      "claude-plugin/.claude-plugin/plugin.json",
+      "claude-plugin/skills/memex/SKILL.md",
+      "claude-plugin/README.md",
+      ".claude-plugin/marketplace.json"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "memex",
+  "description": "Workflow skill for memex-enabled repositories. Teaches autonomous agents how to track development as nodes in the .memex/ DAG: orient via `memex context`, pick a parent, branch, create a node before coding, record decisions/rejected/open-threads as work progresses, and resolve cleanly.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Maximiliano Rios",
+    "email": "max@maxrios.dev"
+  }
+}

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -1,0 +1,60 @@
+# memex Claude plugin
+
+A Claude Code plugin that ships a single skill — `memex` — teaching autonomous agents how to use the [memex](../README.md) CLI in any repository tracked with it.
+
+## What it does
+
+memex tracks development as a versioned DAG of nodes under `.memex/`. The workflow (find a parent, branch, create a node, record decisions, resolve) lives in [AGENTS.md](../AGENTS.md) for contributors to *this* repository. The plugin externalizes that workflow as a Claude skill so any agent working in *any* memex-enabled repo picks up the same guidance without copy-pasting instructions into a project's `CLAUDE.md`.
+
+The skill is triggered when:
+
+- The agent is about to make a code change in a repo containing a `.memex/` directory.
+- The user mentions memex, nodes, or tracked work.
+- The agent is asked to create, resolve, abandon, or edit a node.
+
+## Layout
+
+```
+claude-plugin/
+├── .claude-plugin/
+│   └── plugin.json
+├── skills/
+│   └── memex/
+│       └── SKILL.md
+└── README.md
+```
+
+## Installation
+
+The memex repository is itself a Claude Code marketplace (see `.claude-plugin/marketplace.json` at the repo root). Add the marketplace, then install the plugin:
+
+```
+claude plugin marketplace add /path/to/memex      # or a GitHub URL once published
+claude plugin install memex@memex
+```
+
+The `memex` CLI must also be installed and on `PATH` — the skill instructs the agent to verify this via `memex --version` before acting.
+
+## Testing locally
+
+The cheapest checks are static:
+
+```
+claude plugin validate /path/to/memex             # marketplace manifest
+claude plugin validate /path/to/memex/claude-plugin   # plugin manifest
+```
+
+For a real end-to-end test, install the plugin (see above), then start a fresh Claude Code session in a *separate* memex-enabled directory — not the memex repo itself, since its AGENTS.md would prime the model artificially. A minimal fixture:
+
+```
+mkdir /tmp/memex-test && cd /tmp/memex-test
+git init && memex init
+memex node edit --goal "Some toy project" --decision "Some decision"
+memex node create --parent <root-id> --goal "First feature"
+```
+
+Then ask the agent in that session to add a feature. The skill should trigger and the agent should orient via `memex context` before doing anything else. Iterate on `SKILL.md`, then `claude plugin marketplace update memex` to reload.
+
+## Versioning
+
+The plugin lives inside the memex repository so its skill stays in lockstep with the CLI it describes. Any PR that changes a memex subcommand or flag should update `skills/memex/SKILL.md` in the same diff.

--- a/claude-plugin/skills/memex/SKILL.md
+++ b/claude-plugin/skills/memex/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: memex
+description: Workflow for repositories tracked with memex — a CLI that records development as a versioned DAG of nodes under .memex/. Use whenever you are about to make a code change in a repo containing a .memex/ directory, when the user references memex, nodes, or tracked work, or when asked to create, resolve, abandon, or edit a node. Covers orienting in the graph via `memex context`, finding the right parent, branching, creating a node before writing code, recording decisions/artifacts/open-threads/rejected alternatives as you go, and resolving cleanly.
+---
+
+# memex workflow
+
+memex tracks development as a versioned DAG of nodes stored under `.memex/`. Every feature, fix, or refactor gets a node. This skill is the contract for working in a memex-enabled repository.
+
+## Detect
+
+A repository is memex-enabled if `.memex/` exists at the repo root. If absent, this skill does not apply — ask the user whether to run `memex init` before proceeding.
+
+Confirm the CLI is on PATH:
+
+```
+memex --version
+```
+
+If the command is missing, stop and tell the user — do not try to write to `.memex/` by hand.
+
+## Orient before doing anything else
+
+Whenever you are joining in-progress work, resuming after a break, or evaluating a candidate parent for new work, start with:
+
+```
+memex context --format xml
+```
+
+This returns the project root's goal/decisions, the trimmed ancestor chain, and the active node's full summary in a single structured payload. Prefer this over chaining `memex node show` + `memex graph` — one call, output shaped for parsing.
+
+- `memex context --id <id> --format xml` to orient on a specific node instead of the active one.
+- `--format xml` for agent consumption (most reliable to parse); `--format markdown` if the user will read it.
+- `--depth N` to widen the ancestor window on deep branches; `--depth 0` for a minimal root+current payload.
+
+## Before any code change
+
+1. **Find the parent.** Choose based on what your work *depends on*, not what is most recent.
+   - `memex graph view` — visualize the DAG.
+   - `memex node list` — IDs, parents, statuses, goals.
+   - `memex search <keyword>` — full-text search over node summaries; use domain terms (e.g. `config`, `search`, `rename`).
+   - Attach to the node whose scope you're extending, even if it isn't the tip.
+   - Once you have a candidate, run `memex context --id <candidate> --format xml` to confirm its scope matches what you're about to attach to.
+
+2. **Branch** from main: `git checkout -b <type>/<name>` (`feat/...`, `fix/...`, `chore/...`, `test/...`, `docs/...`).
+
+3. **Create the node before writing code:**
+
+   ```
+   memex node create --parent <id> --goal "<goal>"
+   ```
+
+   A short placeholder goal is fine if scope is uncertain — refine it later with `memex node edit --goal "..."`.
+
+## While implementing
+
+Record context as you go, not after. Each flag appends without touching other fields (except `--goal`, which overwrites):
+
+```
+memex node edit --decision "chose X over Y because Z"
+memex node edit --artifact "path/to/key/file"
+memex node edit --open-thread "question to revisit"
+memex node edit --rejected $'description = "Alternative approach"\nreason = "Why rejected"'
+memex node edit --goal "Updated goal if scope changed"
+```
+
+Use `--summary` only for a full bulk replacement (e.g. bootstrapping from a plan).
+
+**Two prompts to keep in mind:**
+
+- For every `--decision` you record, ask: *what alternative did I deliberately not take, and why?* If there's an answer, that's a `--rejected`.
+- Before resolving, ask: *what question did I defer, what caveat did I notice, what did I leave for later?* Each one is an `--open-thread`.
+
+`--rejected` and `--open-thread` are the under-used fields. Using them is the difference between a node that captures *why* the work landed this way and one that only captures *what* shipped.
+
+## Finishing
+
+1. Run the project's verification commands (lint, format, tests). All must pass before resolving.
+2. Resolve or abandon:
+   - `memex node resolve` when the work is complete.
+   - `memex node abandon` if the approach turned out wrong or was superseded — leave a note in the summary explaining why.
+3. Commit source changes **and** `.memex/nodes/` together — they describe the same unit of work.
+4. **Never** commit `.memex/state.json`. It is per-developer active-node state and creates guaranteed merge conflicts. The default `.memex/.gitignore` already excludes it; do not override.
+
+## Don't
+
+- Don't edit resolved nodes. They are immutable history — record changes in the *current* node, even if the rename or move touches files an older node listed as artifacts.
+- Don't write directly to `.memex/` or bundle multiple nodes per file. Always use the CLI.
+- Don't skip node creation for "small" changes. The graph's value is completeness; one missing node breaks the chain for everything downstream.


### PR DESCRIPTION
## Summary

- Add a Claude Code plugin under `claude-plugin/` that ships a single `memex` skill, externalizing the AGENTS.md workflow so any autonomous agent working in *any* memex-enabled repo picks up the same guidance — no copy-paste into per-project `CLAUDE.md`.
- The skill promotes `memex context --format xml` to the orientation step ahead of `list`/`show`/`graph`, since it's the only CLI command that delivers pre-shaped ancestor context in a single call.
- Make the memex repo itself a marketplace via `.claude-plugin/marketplace.json`, so the plugin is installable from a local checkout (or a GitHub URL once published) without any extra packaging.
- Plugin co-located with the CLI on purpose: any PR that changes a subcommand or flag is forced to update `SKILL.md` in the same diff — separate-repo would allow silent drift.

## Test plan

- [x] `claude plugin validate ./` — marketplace manifest passes.
- [x] `claude plugin validate ./claude-plugin` — plugin manifest passes.
- [x] `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets` all pass (no Rust changed, but verified as required by the workflow).
- [x] Manual end-to-end: installed the plugin from a local marketplace, started a fresh Claude Code session in a separate `memex init`-ed fixture, confirmed the skill triggers on coding prompts and the agent orients via `memex context` before acting.

## Follow-ups (open threads on node f73e3f12)

- Decide whether to slim AGENTS.md once the skill exists (drop the "how to use memex" section and let the skill carry it) or keep both as belt-and-suspenders.
- Add CI that validates the skill's example invocations against the actual `memex` binary, so a flag rename in `main.rs` would fail CI instead of silently breaking `SKILL.md`.
- Decide a publication path (claude-plugins-official marketplace, memex-owned marketplace, or plain GitHub URL).
- Revisit version-aware skill behavior once memex hits 1.0 and CLI surface stability matters across versions.