### PR TITLE
docs: track each release cut as its own memex node

### DIFF
--- a/.memex/nodes/38266f86-b622-4956-a727-97fefbcf58c1.json
+++ b/.memex/nodes/38266f86-b622-4956-a727-97fefbcf58c1.json
@@ -1,0 +1,37 @@
+{
+  "id": "38266f86-b622-4956-a727-97fefbcf58c1",
+  "parent_ids": [
+    "df31d357-3578-40f6-ac0b-787c9471b9d1"
+  ],
+  "git_ref": "main (b8f6a035)",
+  "created_at": "2026-05-12T03:38:09.675254Z",
+  "updated_at": "2026-05-12T03:48:59.171052Z",
+  "summary": {
+    "goal": "Make release cuts memex-native: each release gets its own tracked node, so the release-prep PR satisfies memex-check naturally without [skip memex]",
+    "decisions": [
+      "Each release cut creates its own memex node (parent = main tip at the time of release). This makes the release-prep PR satisfy memex-check naturally and captures release-scope context — what shipped, what was deferred — in the graph alongside development work.",
+      "Release flow switches from direct-push-to-main (original RELEASING.md v0.1.0) to a PR-based flow with branch release/v<version>. Keeps human review on every release, runs CI + memex-check on the version bump, and matches the rest of the project's PR-based contribution model."
+    ],
+    "rejected_approaches": [
+      {
+        "description": "Add [skip memex] to the release-prep PR title to bypass memex-check",
+        "reason": "Functionally simplest, but special-cases the release PR with a marker that future maintainers might cargo-cult onto other PRs. Treating each release as a tracked node fits the project philosophy (\"memex tracks its own development\") and removes the bypass altogether — no marker to misuse."
+      },
+      {
+        "description": "Loosen memex-check to auto-bypass PRs that only touch Cargo.toml/Cargo.lock/CHANGELOG.md",
+        "reason": "Adds logic and a maintenance surface to the workflow for a once-per-release case. Easier to put the burden on the maintainer (create a node) than on the check (detect the shape of a release PR)."
+      },
+      {
+        "description": "Direct-push-to-main for the release commit (original v0.1.0 RELEASING.md)",
+        "reason": "memex-check is PR-only, so direct push does bypass it — but loses PR review on the version bump and the changelog roll, and is inconsistent with the rest of the contribution model. Worth keeping the same review gate for releases as for any other change."
+      }
+    ],
+    "open_threads": [],
+    "key_artifacts": [
+      "RELEASING.md"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,25 +2,43 @@
 
 This document describes how to cut a release. The release workflow at `.github/workflows/release.yml` runs on every `v*` tag, builds binaries for Linux, macOS (Intel + Apple Silicon), and Windows, attaches them with SHA-256 checksums to a draft GitHub release, and publishes the crate to crates.io.
 
+Each release is itself tracked as a memex node so the graph captures *what shipped* alongside *how it was built*, and the release-prep PR satisfies `memex-check` naturally — no `[skip memex]` bypass needed.
+
 ## Prerequisites (one-time)
 
 - A `CARGO_REGISTRY_TOKEN` secret on the GitHub repo, scoped to publish the `memex` crate on [crates.io](https://crates.io/). Generate at <https://crates.io/me> and add via repo Settings → Secrets and variables → Actions.
 
 ## Cutting a release
 
-1. Pick a version. memex follows [SemVer](https://semver.org/): bump `MINOR` for new features, `PATCH` for bug fixes only. While the project is in `0.x`, MINOR bumps may include breaking changes.
+1. **Pick a version.** memex follows [SemVer](https://semver.org/): bump `MINOR` for new features, `PATCH` for bug fixes only. While the project is in `0.x`, MINOR bumps may include breaking changes.
 
-2. From a clean `main`:
+2. **Branch from a clean `main`:**
 
    ```
    git checkout main && git pull
+   git checkout -b release/v<version>
    ```
 
-3. Update `version` in `Cargo.toml` and run `cargo build` once so `Cargo.lock` picks up the new version.
+3. **Create the release node.** Parent is the tip of `main` (find via `memex node list` or `memex graph view`):
 
-4. In `CHANGELOG.md`, move entries from `## [Unreleased]` into a new dated section for the version, and update the version-comparison links at the bottom.
+   ```
+   memex node create --parent <main-tip-id> --goal "Release v<version>" --tag release
+   ```
 
-5. Verify locally:
+4. **Bump the version.** Edit `version` in `Cargo.toml`, then run `cargo build` once so `Cargo.lock` picks up the new version.
+
+5. **Roll the changelog.** In `CHANGELOG.md`, move entries from `## [Unreleased]` into a new dated section for the version, and update the version-comparison links at the bottom.
+
+6. **Record release context on the node.** At minimum:
+
+   ```
+   memex node edit --artifact "Cargo.toml"
+   memex node edit --artifact "CHANGELOG.md"
+   ```
+
+   If anything notable was deferred from this release, capture it as an open thread; if a scope decision was made (e.g. holding a feature back, choosing a version-bump tier), record it as a decision.
+
+7. **Verify locally:**
 
    ```
    cargo fmt --all -- --check
@@ -31,22 +49,32 @@ This document describes how to cut a release. The release workflow at `.github/w
 
    All must pass.
 
-6. Commit (one commit is fine for the version bump + changelog):
+8. **Resolve the node:**
 
    ```
-   git add Cargo.toml Cargo.lock CHANGELOG.md
+   memex node resolve
+   ```
+
+9. **Commit, push, open PR, merge.** The release-prep commit includes the version bump, changelog roll, and the new node JSON:
+
+   ```
+   git add Cargo.toml Cargo.lock CHANGELOG.md .memex/nodes/*.json
    git commit -m "chore: release v<version>"
-   git push
+   git push -u origin release/v<version>
+   gh pr create --title "chore: release v<version>" --body "Release-prep PR. See node <short-id> for context."
    ```
 
-7. Tag and push the tag:
+   Once CI and `memex-check` go green, merge the PR.
 
-   ```
-   git tag v<version>
-   git push origin v<version>
-   ```
+10. **Tag the merged commit:**
 
-8. Watch the release workflow in GitHub Actions. When it finishes:
-   - Confirm the draft GitHub release has all four target archives + checksums attached.
-   - Confirm `https://crates.io/crates/memex` shows the new version.
-   - Promote the draft release to published.
+    ```
+    git checkout main && git pull
+    git tag v<version>
+    git push origin v<version>
+    ```
+
+11. **Watch the release workflow** in GitHub Actions. When it finishes:
+    - Confirm the draft GitHub release has all four target archives + checksums attached.
+    - Confirm `https://crates.io/crates/memex` shows the new version.
+    - Promote the draft release to published.


### PR DESCRIPTION
## Summary

Follow-up to #56. The original RELEASING.md had the release commit push directly to main, which works (memex-check is PR-only) but skips review on the version bump and is inconsistent with the rest of the contribution model. Switch the release flow to:

- Branch `release/v<version>` from main
- **Create a memex node** parented on the main tip with goal "Release v<version>" before bumping anything
- Bump `Cargo.toml`, roll `CHANGELOG.md`, record release-scope context on the node (deferred items, scope decisions)
- Open a PR — the new node makes memex-check pass naturally, no `[skip memex]` needed
- Merge, then tag the merged commit

Captures release scope in the graph alongside development work, removes the need for any bypass marker.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --all-targets` — 36 passed
- [x] CI green on this PR
- [x] `memex-check` green on this PR (the PR itself creates a new node — node 38266f86 — which is the dogfooding case for the new flow)