### PR TITLE
chore: rename published crate to memex-cli

### DIFF
--- a/.memex/nodes/d837d53b-259a-43d5-a5d7-c874cfc25c05.json
+++ b/.memex/nodes/d837d53b-259a-43d5-a5d7-c874cfc25c05.json
@@ -1,0 +1,41 @@
+{
+  "id": "d837d53b-259a-43d5-a5d7-c874cfc25c05",
+  "parent_ids": [
+    "c282bd40-4f3f-41a2-b363-4a86e7f58f42"
+  ],
+  "git_ref": "chore/rename-crate-to-memex-cli (a11f6efe)",
+  "created_at": "2026-05-12T04:19:08.858609Z",
+  "updated_at": "2026-05-12T04:20:10.276073Z",
+  "summary": {
+    "goal": "Rename published crate from 'memex' to 'memex-cli' — the 'memex' name is taken on crates.io by an unrelated project (ooojustin/memex, 0.3.0, ~12k downloads). Binary name and project name stay 'memex'; only the crates.io listing changes.",
+    "decisions": [
+      "Published crate is 'memex-cli' (a different active project, ooojustin/memex, owns 'memex' on crates.io: 0.3.0, ~12k downloads, 'turn your Rust workspace into human-readable docs').",
+      "Keep the [[bin]] name = 'memex' and the clap #[command(name = 'memex')] in src/main.rs. The published crate is the only thing renamed; the installed binary, the repo, the CLI's self-identification (memex --version, --help) all stay 'memex'. User-facing impact is one line: 'cargo install memex-cli' instead of 'cargo install memex'."
+    ],
+    "rejected_approaches": [
+      {
+        "description": "Pick a more thematic name (memex-graph, memex-dag, memex-dev)",
+        "reason": "memex-cli is the standard fallback pattern for CLIs whose preferred name is taken on crates.io (similar to many examples). Thematic names overspecify and lock us into a frame (graph, dag, dev) that may not age well. -cli is neutral and conventional."
+      },
+      {
+        "description": "Skip crates.io entirely; distribute only via GitHub releases + cargo install --git",
+        "reason": "Loses crates.io discoverability. Users searching for memex on crates.io see the other project and assume that's us. The rename cost is one line in Cargo.toml plus a README note; cheaper than the discoverability loss."
+      },
+      {
+        "description": "Ask ooojustin to transfer the memex name",
+        "reason": "Active project (last updated 2026-03-29, 0.3.0, ~12k downloads). Vanishingly unlikely to succeed and slow even if they considered it. Not a real option."
+      }
+    ],
+    "open_threads": [
+      "Before re-tagging v0.1.0: delete the existing draft GitHub release and its tag with 'gh release delete v0.1.0 --cleanup-tag --yes' (cleanup-tag drops both the draft and the tag in one go). Then 'git fetch --tags --prune --prune-tags' locally, retag main, and push the tag — the workflow will run end-to-end including the now-valid crates.io publish."
+    ],
+    "key_artifacts": [
+      "Cargo.toml",
+      "Cargo.lock",
+      "README.md"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memex"
+name = "memex-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "memex"
+name = "memex-cli"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.74"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Conversations are ephemeral and flat, but real development is hierarchical and b
 
 ### From crates.io
 
+The crate is published as `memex-cli` (the `memex` name is held by an unrelated crate); the installed binary is `memex`.
+
 ```
-cargo install memex
+cargo install memex-cli
 ```
 
 ### Prebuilt binaries


### PR DESCRIPTION
## Summary

The v0.1.0 release workflow's \`publish-crate\` step failed with:

> \`status 403 Forbidden: this crate exists but you don't seem to be an owner\`

The \`memex\` name on crates.io is held by [\`ooojustin/memex\`](https://github.com/ooojustin/memex) (0.3.0, ~12k downloads, "turn your Rust workspace into human-readable docs"). Rename the published crate to \`memex-cli\` — the standard fallback pattern.

What changes:

- \`Cargo.toml\` \`[package] name\`: \`memex\` → \`memex-cli\`
- \`README.md\` install line: \`cargo install memex\` → \`cargo install memex-cli\` (with a brief note about why)
- \`Cargo.lock\` regenerated

What stays:

- The \`[[bin]] name = "memex"\` — installed binary on disk is still \`memex\`
- \`#[command(name = "memex")]\` in \`src/main.rs\` — \`memex --version\`, \`memex --help\` still self-identify as memex
- Repo name, branding, docs — all still memex
- GitHub release artifact names (\`memex-v0.1.0-*.tar.gz\`) — unchanged

## Post-merge

Re-cut v0.1.0 cleanly:

\`\`\`
gh release delete v0.1.0 --cleanup-tag --yes
git fetch --tags --prune --prune-tags
git checkout main && git pull
git tag v0.1.0
git push origin v0.1.0
\`\`\`

Workflow will run end-to-end, including the now-valid crates.io publish.

## Test plan

- [x] \`cargo build\` — compiles as \`memex-cli v0.1.0\`
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo test --all-targets\` — 36 passed
- [x] \`cargo package --no-verify --allow-dirty\` — packaged \`memex-cli\` (76 files, 251.7KiB)
- [x] CI green on this PR
- [ ] Post-merge: retag v0.1.0; confirm all 4 build jobs, GitHub release, and crates.io publish succeed