### PR TITLE
feat: add memex pr-context subcommand and PR-comment workflow (closes #61)

### DIFF
--- a/.github/workflows/memex-pr-context.yml
+++ b/.github/workflows/memex-pr-context.yml
@@ -1,0 +1,83 @@
+name: memex PR context
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  memex-pr-context:
+    name: Surface memex node context for changed files
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.title, '[skip memex]')"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-pr-context-${{ hashFiles('Cargo.lock') }}
+
+      - name: Build memex
+        run: cargo build --release --locked
+
+      - name: Compute changed files and render PR context
+        id: render
+        run: |
+          BASE=origin/${{ github.base_ref }}
+          mapfile -t FILES < <(git diff --name-only "$BASE"...HEAD)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No changed files; skipping comment."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ARGS=()
+          for f in "${FILES[@]}"; do
+            ARGS+=(--file "$f")
+          done
+          ./target/release/memex pr-context "${ARGS[@]}" > pr-context.md
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert PR comment
+        if: steps.render.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('pr-context.md', 'utf8');
+            const marker = '<!-- memex-pr-context -->';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+
+            const existing = comments.find((c) => c.body && c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated existing comment #${existing.id}.`);
+            } else {
+              const { data: created } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+              core.info(`Created comment #${created.id}.`);
+            }

--- a/.memex/nodes/7514851c-6b65-4fda-b09f-82cc5d5060d6.json
+++ b/.memex/nodes/7514851c-6b65-4fda-b09f-82cc5d5060d6.json
@@ -1,0 +1,37 @@
+{
+  "id": "7514851c-6b65-4fda-b09f-82cc5d5060d6",
+  "parent_ids": [
+    "75387180-b66d-4396-8403-3758b1e94a45"
+  ],
+  "git_ref": "feat/pr-context-action (17ef31aa)",
+  "created_at": "2026-05-14T22:12:29.388620Z",
+  "updated_at": "2026-05-14T22:14:44.192519Z",
+  "summary": {
+    "goal": "Cap pr-context output to N most recent matches (default 5) and fix clippy unnecessary_sort_by lint",
+    "decisions": [
+      "default limit = 5 — keeps comment under ~5KB on hot files while preserving the most recent context (which is what reviewers care about); 0 = unlimited for power users",
+      "fixed clippy unnecessary_sort_by by switching matches.sort_by(|a,b| b.cmp(&a)) to matches.sort_by_key(|n| std::cmp::Reverse(n.created_at)) — older toolchain locally did not flag this; only Linux/Windows runners with newer Rust did",
+      "renders cap as a footer with omitted count rather than truncating silently — preserves the user's ability to know there's more by passing --limit 0"
+    ],
+    "rejected_approaches": [
+      {
+        "description": "Truncate per-node fields (e.g., first 3 decisions only) in addition to capping node count",
+        "reason": "Adds a second axis of complexity (per-node truncation rules) for marginal size win. Capping node count is the simpler v1 lever; per-node trim can be added later if real PRs still produce oversized comments."
+      },
+      {
+        "description": "Pick limit=3 as the default",
+        "reason": "5 keeps room for the realistic case of a node touching ~3-4 files where each file has its own most-recent-touch node. 3 felt aggressive; default can be lowered if usage shows otherwise."
+      }
+    ],
+    "open_threads": [],
+    "key_artifacts": [
+      "src/commands/pr_context.rs",
+      "src/main.rs",
+      "tests/integration_tests.rs",
+      "README.md"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/.memex/nodes/75387180-b66d-4396-8403-3758b1e94a45.json
+++ b/.memex/nodes/75387180-b66d-4396-8403-3758b1e94a45.json
@@ -1,0 +1,45 @@
+{
+  "id": "75387180-b66d-4396-8403-3758b1e94a45",
+  "parent_ids": [
+    "af5774e3-d353-477c-93ea-8f465e62028e"
+  ],
+  "git_ref": "feat/pr-context-action (ff9ae323)",
+  "created_at": "2026-05-14T21:48:30.682375Z",
+  "updated_at": "2026-05-14T21:59:31.289281Z",
+  "summary": {
+    "goal": "Add memex pr-context subcommand and GitHub Action that surfaces relevant memex node context as a PR comment based on changed files (closes #61)",
+    "decisions": [
+      "added pr-context as a new top-level subcommand (not under node) — it operates on the whole graph, not a single node, so the parallel structure with context/search/graph fits better than node/pr-context",
+      "exact-string artifact match in v1 — directory-prefix or fuzzy match deferred to open thread; false-positive comments are worse noise than false negatives",
+      "sorted by created_at desc so the most recent prior work shows first; reviewers care most about the latest context for each file",
+      "workflow uses actions/github-script to upsert via marker-prefix lookup; same idempotency pattern any reviewer would write by hand",
+      "build memex from source in CI rather than downloading a release binary — keeps the workflow self-contained and means the action always reflects the version of memex in the repo"
+    ],
+    "rejected_approaches": [
+      {
+        "description": "match nodes via directory-prefix or partial path overlap in v1",
+        "reason": "Risk of low-precision matches that surface unrelated nodes; better to ship exact-match v1, observe usage, and add prefix opt-in if needed."
+      },
+      {
+        "description": "Ship a versioned reusable composite/JS Action under .github/actions/ for external consumers",
+        "reason": "Larger surface to maintain (versioning, marketplace, breaking-change story); v1 is a workflow file consumers can copy. Promote to a reusable action once the shape stabilizes."
+      }
+    ],
+    "open_threads": [
+      "Surface open_threads from ancestor nodes whose artifacts overlap, not just direct artifact matches — would catch context that lives one branch up",
+      "Add directory-prefix matching as opt-in (e.g., --match-prefix) once we see real usage and know whether the noise is acceptable",
+      "Cap output length when many nodes match (currently unbounded; could blow past GH comment size on large PRs)",
+      "Extract to a versioned reusable Action under .github/actions/memex-pr-context/ once the format is stable enough to commit to"
+    ],
+    "key_artifacts": [
+      "src/commands/pr_context.rs",
+      "src/commands/mod.rs",
+      "src/main.rs",
+      "tests/integration_tests.rs",
+      ".github/workflows/memex-pr-context.yml"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Render a markdown payload listing every node whose `key_artifacts` exact-match o
 |---|---|
 | `--file <path>` | Repo-relative path to consider. Repeatable. |
 | `--marker <html>` | HTML marker comment used by automation to find and update an existing comment idempotently. Defaults to `<!-- memex-pr-context -->`. |
+| `--limit <N>` | Cap on the number of nodes rendered (most recent first). Default `5`. Pass `0` for no cap. When the cap triggers, a one-line footer reports how many older matches were omitted. |
 
 Output is written to stdout. The first line is always the marker, so callers can locate prior comments without re-parsing the body.
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,29 @@ ASCII tree of the full conversation graph. Shows status icons and marks the acti
 
 Full-text search across all node summaries, including goals, decisions, artifacts, open threads, rejected approaches, and tags.
 
+### `memex pr-context --file <path> [--file <path> ...]`
+
+Render a markdown payload listing every node whose `key_artifacts` exact-match one of the given files. Sorted most-recent-first. Designed to be piped into a PR comment so reviewers see what was tried, rejected, or left open in earlier work on these files.
+
+| Flag | Description |
+|---|---|
+| `--file <path>` | Repo-relative path to consider. Repeatable. |
+| `--marker <html>` | HTML marker comment used by automation to find and update an existing comment idempotently. Defaults to `<!-- memex-pr-context -->`. |
+
+Output is written to stdout. The first line is always the marker, so callers can locate prior comments without re-parsing the body.
+
+---
+
+## GitHub Action
+
+`.github/workflows/memex-pr-context.yml` ships with the repo and surfaces relevant memex node context as a PR comment on every push. To use it in another project, copy the workflow file and replace the build step with `cargo install --locked memex-cli`. The workflow:
+
+1. Computes changed files via `git diff --name-only origin/<base>...HEAD`.
+2. Pipes them to `memex pr-context`.
+3. Looks for an existing PR comment whose body starts with the marker, then updates it in place or creates a new one.
+
+Pull request titles containing `[skip memex]` skip the comment.
+
 ---
 
 ## Workflow

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,4 +2,5 @@ pub mod context;
 pub mod graph;
 pub mod init;
 pub mod node;
+pub mod pr_context;
 pub mod search;

--- a/src/commands/pr_context.rs
+++ b/src/commands/pr_context.rs
@@ -1,0 +1,245 @@
+use std::collections::HashSet;
+
+use anyhow::Result;
+
+use crate::models::{ConversationNode, NodeStatus};
+use crate::store::GraphStore;
+
+pub const DEFAULT_MARKER: &str = "<!-- memex-pr-context -->";
+
+/// Find nodes whose `key_artifacts` exact-match any of the given file paths.
+/// Returns nodes sorted by `created_at` descending (most recent first).
+pub(crate) fn matching_nodes<'a>(
+    nodes: &'a [ConversationNode],
+    files: &[String],
+) -> Vec<&'a ConversationNode> {
+    let file_set: HashSet<&str> = files.iter().map(|f| f.as_str()).collect();
+    let mut matches: Vec<&ConversationNode> = nodes
+        .iter()
+        .filter(|n| {
+            n.summary
+                .key_artifacts
+                .iter()
+                .any(|a| file_set.contains(a.as_str()))
+        })
+        .collect();
+    matches.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    matches
+}
+
+/// Format the matched nodes as a markdown PR comment body.
+pub(crate) fn format_comment(matches: &[&ConversationNode], marker: &str) -> String {
+    let mut out = String::new();
+    out.push_str(marker);
+    out.push('\n');
+    out.push_str("## memex context for this PR\n\n");
+
+    if matches.is_empty() {
+        out.push_str("_No prior memex nodes touched the changed files._\n");
+        return out;
+    }
+
+    out.push_str(
+        "Prior memex nodes that touched files in this PR. Use this to see what was tried, \
+         rejected, or left open in earlier work on these files.\n\n",
+    );
+
+    for node in matches {
+        let status_label = match node.status {
+            NodeStatus::Active => "Active",
+            NodeStatus::Resolved => "Resolved",
+            NodeStatus::Abandoned => "Abandoned",
+        };
+        out.push_str(&format!(
+            "### `{}` — {} ({})\n\n",
+            node.short_id(),
+            node.summary.goal,
+            status_label
+        ));
+
+        if !node.summary.key_artifacts.is_empty() {
+            out.push_str("**Artifacts:** ");
+            out.push_str(&node.summary.key_artifacts.join(", "));
+            out.push_str("\n\n");
+        }
+
+        if !node.summary.decisions.is_empty() {
+            out.push_str("**Decisions:**\n");
+            for d in &node.summary.decisions {
+                out.push_str(&format!("- {}\n", d));
+            }
+            out.push('\n');
+        }
+
+        if !node.summary.rejected_approaches.is_empty() {
+            out.push_str("**Rejected approaches:**\n");
+            for r in &node.summary.rejected_approaches {
+                out.push_str(&format!("- {} — _{}_\n", r.description, r.reason));
+            }
+            out.push('\n');
+        }
+
+        if !node.summary.open_threads.is_empty() {
+            out.push_str("**Open threads:**\n");
+            for t in &node.summary.open_threads {
+                out.push_str(&format!("- {}\n", t));
+            }
+            out.push('\n');
+        }
+    }
+
+    out
+}
+
+pub fn run(files: &[String], marker: &str) -> Result<()> {
+    let store = GraphStore::open_from_cwd()?;
+    let nodes = store.load_all_nodes()?;
+    let matches = matching_nodes(&nodes, files);
+    let body = format_comment(&matches, marker);
+    print!("{}", body);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{NodeStatus, NodeSummary, RejectedApproach};
+    use chrono::{Duration, TimeZone, Utc};
+    use uuid::Uuid;
+
+    fn make_node(goal: &str, artifacts: Vec<&str>, created_offset_secs: i64) -> ConversationNode {
+        let base = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        ConversationNode {
+            id: Uuid::new_v4(),
+            parent_ids: vec![],
+            git_ref: None,
+            created_at: base + Duration::seconds(created_offset_secs),
+            updated_at: base + Duration::seconds(created_offset_secs),
+            summary: NodeSummary {
+                goal: goal.to_string(),
+                decisions: vec![],
+                rejected_approaches: vec![],
+                open_threads: vec![],
+                key_artifacts: artifacts.into_iter().map(String::from).collect(),
+            },
+            raw_transcript_ref: None,
+            tags: vec![],
+            status: NodeStatus::Resolved,
+        }
+    }
+
+    #[test]
+    fn matches_exact_artifact_path() {
+        let nodes = vec![
+            make_node("touched main", vec!["src/main.rs"], 0),
+            make_node("touched store", vec!["src/store.rs"], 10),
+        ];
+        let files = vec!["src/main.rs".to_string()];
+        let m = matching_nodes(&nodes, &files);
+        assert_eq!(m.len(), 1);
+        assert_eq!(m[0].summary.goal, "touched main");
+    }
+
+    #[test]
+    fn no_match_returns_empty() {
+        let nodes = vec![make_node("touched main", vec!["src/main.rs"], 0)];
+        let files = vec!["src/other.rs".to_string()];
+        assert!(matching_nodes(&nodes, &files).is_empty());
+    }
+
+    #[test]
+    fn match_is_case_sensitive() {
+        let nodes = vec![make_node("touched main", vec!["src/Main.rs"], 0)];
+        let files = vec!["src/main.rs".to_string()];
+        assert!(matching_nodes(&nodes, &files).is_empty());
+    }
+
+    #[test]
+    fn match_does_not_use_directory_prefix() {
+        // "src" should not match "src/main.rs" — exact only.
+        let nodes = vec![make_node("touched main", vec!["src/main.rs"], 0)];
+        let files = vec!["src".to_string()];
+        assert!(matching_nodes(&nodes, &files).is_empty());
+    }
+
+    #[test]
+    fn matches_sorted_by_created_at_desc() {
+        let nodes = vec![
+            make_node("oldest", vec!["src/main.rs"], 0),
+            make_node("newest", vec!["src/main.rs"], 100),
+            make_node("middle", vec!["src/main.rs"], 50),
+        ];
+        let files = vec!["src/main.rs".to_string()];
+        let m = matching_nodes(&nodes, &files);
+        assert_eq!(m.len(), 3);
+        assert_eq!(m[0].summary.goal, "newest");
+        assert_eq!(m[1].summary.goal, "middle");
+        assert_eq!(m[2].summary.goal, "oldest");
+    }
+
+    #[test]
+    fn dedup_node_with_multiple_matching_artifacts() {
+        // A node with two artifacts both in the changed-file set must appear once.
+        let nodes = vec![make_node(
+            "touched both",
+            vec!["src/main.rs", "src/store.rs"],
+            0,
+        )];
+        let files = vec!["src/main.rs".to_string(), "src/store.rs".to_string()];
+        let m = matching_nodes(&nodes, &files);
+        assert_eq!(m.len(), 1);
+    }
+
+    #[test]
+    fn empty_body_for_no_matches() {
+        let body = format_comment(&[], DEFAULT_MARKER);
+        assert!(body.starts_with(DEFAULT_MARKER));
+        assert!(body.contains("No prior memex nodes touched"));
+    }
+
+    #[test]
+    fn body_includes_marker_first_line() {
+        let body = format_comment(&[], DEFAULT_MARKER);
+        let first_line = body.lines().next().unwrap();
+        assert_eq!(first_line, DEFAULT_MARKER);
+    }
+
+    #[test]
+    fn body_renders_node_sections() {
+        let mut node = make_node("ship the feature", vec!["src/main.rs"], 0);
+        node.summary.decisions.push("chose A".to_string());
+        node.summary.rejected_approaches.push(RejectedApproach {
+            description: "B".to_string(),
+            reason: "too slow".to_string(),
+        });
+        node.summary
+            .open_threads
+            .push("revisit logging".to_string());
+
+        let body = format_comment(&[&node], DEFAULT_MARKER);
+        assert!(body.contains("ship the feature"));
+        assert!(body.contains("**Artifacts:** src/main.rs"));
+        assert!(body.contains("**Decisions:**"));
+        assert!(body.contains("- chose A"));
+        assert!(body.contains("**Rejected approaches:**"));
+        assert!(body.contains("B — _too slow_"));
+        assert!(body.contains("**Open threads:**"));
+        assert!(body.contains("- revisit logging"));
+    }
+
+    #[test]
+    fn body_omits_empty_sections() {
+        let node = make_node("bare node", vec!["src/main.rs"], 0);
+        let body = format_comment(&[&node], DEFAULT_MARKER);
+        assert!(body.contains("bare node"));
+        assert!(!body.contains("**Decisions:**"));
+        assert!(!body.contains("**Rejected approaches:**"));
+        assert!(!body.contains("**Open threads:**"));
+    }
+
+    #[test]
+    fn custom_marker_used() {
+        let body = format_comment(&[], "<!-- custom -->");
+        assert!(body.starts_with("<!-- custom -->"));
+    }
+}

--- a/src/commands/pr_context.rs
+++ b/src/commands/pr_context.rs
@@ -6,6 +6,7 @@ use crate::models::{ConversationNode, NodeStatus};
 use crate::store::GraphStore;
 
 pub const DEFAULT_MARKER: &str = "<!-- memex-pr-context -->";
+pub const DEFAULT_LIMIT: usize = 5;
 
 /// Find nodes whose `key_artifacts` exact-match any of the given file paths.
 /// Returns nodes sorted by `created_at` descending (most recent first).
@@ -23,12 +24,14 @@ pub(crate) fn matching_nodes<'a>(
                 .any(|a| file_set.contains(a.as_str()))
         })
         .collect();
-    matches.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    matches.sort_by_key(|n| std::cmp::Reverse(n.created_at));
     matches
 }
 
 /// Format the matched nodes as a markdown PR comment body.
-pub(crate) fn format_comment(matches: &[&ConversationNode], marker: &str) -> String {
+/// `limit` caps the number of nodes rendered (0 = unlimited). When the cap
+/// triggers, a trailing line announces how many older matches were omitted.
+pub(crate) fn format_comment(matches: &[&ConversationNode], marker: &str, limit: usize) -> String {
     let mut out = String::new();
     out.push_str(marker);
     out.push('\n');
@@ -44,7 +47,13 @@ pub(crate) fn format_comment(matches: &[&ConversationNode], marker: &str) -> Str
          rejected, or left open in earlier work on these files.\n\n",
     );
 
-    for node in matches {
+    let (rendered, omitted) = if limit == 0 || matches.len() <= limit {
+        (matches, 0usize)
+    } else {
+        (&matches[..limit], matches.len() - limit)
+    };
+
+    for node in rendered {
         let status_label = match node.status {
             NodeStatus::Active => "Active",
             NodeStatus::Resolved => "Resolved",
@@ -88,14 +97,22 @@ pub(crate) fn format_comment(matches: &[&ConversationNode], marker: &str) -> Str
         }
     }
 
+    if omitted > 0 {
+        out.push_str(&format!(
+            "_{} older matching node{} omitted; raise `--limit` to see more._\n",
+            omitted,
+            if omitted == 1 { "" } else { "s" }
+        ));
+    }
+
     out
 }
 
-pub fn run(files: &[String], marker: &str) -> Result<()> {
+pub fn run(files: &[String], marker: &str, limit: usize) -> Result<()> {
     let store = GraphStore::open_from_cwd()?;
     let nodes = store.load_all_nodes()?;
     let matches = matching_nodes(&nodes, files);
-    let body = format_comment(&matches, marker);
+    let body = format_comment(&matches, marker, limit);
     print!("{}", body);
     Ok(())
 }
@@ -192,14 +209,14 @@ mod tests {
 
     #[test]
     fn empty_body_for_no_matches() {
-        let body = format_comment(&[], DEFAULT_MARKER);
+        let body = format_comment(&[], DEFAULT_MARKER, DEFAULT_LIMIT);
         assert!(body.starts_with(DEFAULT_MARKER));
         assert!(body.contains("No prior memex nodes touched"));
     }
 
     #[test]
     fn body_includes_marker_first_line() {
-        let body = format_comment(&[], DEFAULT_MARKER);
+        let body = format_comment(&[], DEFAULT_MARKER, DEFAULT_LIMIT);
         let first_line = body.lines().next().unwrap();
         assert_eq!(first_line, DEFAULT_MARKER);
     }
@@ -216,7 +233,7 @@ mod tests {
             .open_threads
             .push("revisit logging".to_string());
 
-        let body = format_comment(&[&node], DEFAULT_MARKER);
+        let body = format_comment(&[&node], DEFAULT_MARKER, DEFAULT_LIMIT);
         assert!(body.contains("ship the feature"));
         assert!(body.contains("**Artifacts:** src/main.rs"));
         assert!(body.contains("**Decisions:**"));
@@ -230,7 +247,7 @@ mod tests {
     #[test]
     fn body_omits_empty_sections() {
         let node = make_node("bare node", vec!["src/main.rs"], 0);
-        let body = format_comment(&[&node], DEFAULT_MARKER);
+        let body = format_comment(&[&node], DEFAULT_MARKER, DEFAULT_LIMIT);
         assert!(body.contains("bare node"));
         assert!(!body.contains("**Decisions:**"));
         assert!(!body.contains("**Rejected approaches:**"));
@@ -239,7 +256,61 @@ mod tests {
 
     #[test]
     fn custom_marker_used() {
-        let body = format_comment(&[], "<!-- custom -->");
+        let body = format_comment(&[], "<!-- custom -->", DEFAULT_LIMIT);
         assert!(body.starts_with("<!-- custom -->"));
+    }
+
+    #[test]
+    fn limit_caps_rendered_nodes_and_announces_omitted_count() {
+        let nodes: Vec<ConversationNode> = (0..7)
+            .map(|i| make_node(&format!("node {}", i), vec!["src/main.rs"], i * 10))
+            .collect();
+        let refs: Vec<&ConversationNode> = nodes.iter().collect();
+
+        let body = format_comment(&refs, DEFAULT_MARKER, 3);
+        // First three by position should appear; tail should be omitted.
+        assert!(body.contains("node 0"));
+        assert!(body.contains("node 1"));
+        assert!(body.contains("node 2"));
+        assert!(!body.contains("node 3"));
+        assert!(body.contains("4 older matching nodes omitted"));
+    }
+
+    #[test]
+    fn limit_zero_renders_all_nodes() {
+        let nodes: Vec<ConversationNode> = (0..3)
+            .map(|i| make_node(&format!("node {}", i), vec!["src/main.rs"], i * 10))
+            .collect();
+        let refs: Vec<&ConversationNode> = nodes.iter().collect();
+
+        let body = format_comment(&refs, DEFAULT_MARKER, 0);
+        assert!(body.contains("node 0"));
+        assert!(body.contains("node 1"));
+        assert!(body.contains("node 2"));
+        assert!(!body.contains("omitted"));
+    }
+
+    #[test]
+    fn limit_at_or_above_match_count_omits_no_footer() {
+        let nodes: Vec<ConversationNode> = (0..3)
+            .map(|i| make_node(&format!("node {}", i), vec!["src/main.rs"], i * 10))
+            .collect();
+        let refs: Vec<&ConversationNode> = nodes.iter().collect();
+
+        let body = format_comment(&refs, DEFAULT_MARKER, 3);
+        assert!(!body.contains("omitted"));
+        let body_above = format_comment(&refs, DEFAULT_MARKER, 99);
+        assert!(!body_above.contains("omitted"));
+    }
+
+    #[test]
+    fn limit_one_uses_singular_in_footer() {
+        let nodes: Vec<ConversationNode> = (0..2)
+            .map(|i| make_node(&format!("node {}", i), vec!["src/main.rs"], i * 10))
+            .collect();
+        let refs: Vec<&ConversationNode> = nodes.iter().collect();
+
+        let body = format_comment(&refs, DEFAULT_MARKER, 1);
+        assert!(body.contains("1 older matching node omitted"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,17 @@ enum Commands {
         /// Query string to search for
         query: String,
     },
+
+    /// Render a PR-comment payload listing memex nodes whose key_artifacts match the given files
+    PrContext {
+        /// Changed files (repo-relative paths). Repeatable.
+        #[arg(long = "file", num_args = 1, action = clap::ArgAction::Append)]
+        files: Vec<String>,
+
+        /// HTML marker comment used by callers to find/update the comment idempotently
+        #[arg(long, default_value = commands::pr_context::DEFAULT_MARKER)]
+        marker: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -216,5 +227,7 @@ fn run(cli: Cli) -> Result<()> {
         }
 
         Commands::Search { query } => commands::search::run(&query),
+
+        Commands::PrContext { files, marker } => commands::pr_context::run(&files, &marker),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,10 @@ enum Commands {
         /// HTML marker comment used by callers to find/update the comment idempotently
         #[arg(long, default_value = commands::pr_context::DEFAULT_MARKER)]
         marker: String,
+
+        /// Cap on the number of nodes rendered (most recent first; 0 = unlimited)
+        #[arg(long, default_value_t = commands::pr_context::DEFAULT_LIMIT)]
+        limit: usize,
     },
 }
 
@@ -228,6 +232,10 @@ fn run(cli: Cli) -> Result<()> {
 
         Commands::Search { query } => commands::search::run(&query),
 
-        Commands::PrContext { files, marker } => commands::pr_context::run(&files, &marker),
+        Commands::PrContext {
+            files,
+            marker,
+            limit,
+        } => commands::pr_context::run(&files, &marker, limit),
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -694,3 +694,94 @@ fn context_depth_trimming() {
         .stdout(predicate::str::contains("Level one node").not())
         .stdout(predicate::str::contains("Current node"));
 }
+
+// ─── pr-context ──────────────────────────────────────────────────────────────
+
+#[test]
+fn pr_context_emits_marker_and_no_match_message_when_empty() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Root");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["pr-context", "--file", "src/nothing.rs"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<!-- memex-pr-context -->"))
+        .stdout(predicate::str::contains(
+            "No prior memex nodes touched the changed files.",
+        ));
+}
+
+#[test]
+fn pr_context_lists_node_with_matching_artifact() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Root");
+    let child = create_node(&tmp, "Touched main");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "edit", "--artifact", "src/main.rs"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["pr-context", "--file", "src/main.rs"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&child))
+        .stdout(predicate::str::contains("Touched main"))
+        .stdout(predicate::str::contains("**Artifacts:** src/main.rs"));
+}
+
+#[test]
+fn pr_context_excludes_non_matching_nodes() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Root");
+    let on_main = create_node(&tmp, "Touched main");
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "edit", "--artifact", "src/main.rs"])
+        .assert()
+        .success();
+
+    let on_store = create_node(&tmp, "Touched store");
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "edit", "--artifact", "src/store.rs"])
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["pr-context", "--file", "src/main.rs"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&on_main))
+        .stdout(predicate::str::contains(&on_store).not());
+}
+
+#[test]
+fn pr_context_supports_custom_marker() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Root");
+
+    memex()
+        .current_dir(tmp.path())
+        .args([
+            "pr-context",
+            "--marker",
+            "<!-- custom-marker -->",
+            "--file",
+            "src/main.rs",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<!-- custom-marker -->"))
+        .stdout(predicate::str::contains("<!-- memex-pr-context -->").not());
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -766,6 +766,30 @@ fn pr_context_excludes_non_matching_nodes() {
 }
 
 #[test]
+fn pr_context_limit_caps_rendered_nodes() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Root");
+
+    // Create 4 child nodes that all touch src/main.rs
+    for i in 0..4 {
+        let _id = create_node(&tmp, &format!("Touch {}", i));
+        memex()
+            .current_dir(tmp.path())
+            .args(["node", "edit", "--artifact", "src/main.rs"])
+            .assert()
+            .success();
+    }
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["pr-context", "--limit", "2", "--file", "src/main.rs"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("2 older matching nodes omitted"));
+}
+
+#[test]
 fn pr_context_supports_custom_marker() {
     let tmp = TempDir::new().unwrap();
     init_in(&tmp);


### PR DESCRIPTION
## Summary

- Adds `memex pr-context --file <path>...` subcommand that emits a markdown payload listing every node whose `key_artifacts` exact-match one of the given files. Output is sorted most-recent-first and prefixed with an HTML marker (`<!-- memex-pr-context -->`) so callers can locate and update an existing comment idempotently.
- Adds `.github/workflows/memex-pr-context.yml` that runs on every PR push: computes changed files via `git diff --name-only`, pipes them to `memex pr-context`, and upserts a single PR comment via `actions/github-script`.
- 11 new tests (7 unit in `pr_context.rs`, 4 integration via `assert_cmd`).

## Why

Closes [#61](https://github.com/maxrios/memex/issues/61). The memex graph is invisible to anyone who doesn't run the CLI — including most reviewers most of the time. Surfacing relevant nodes at the moment a PR is being reviewed is the highest-leverage way to make the graph's value visible to non-users, and gives node authors a concrete reason to write good `decisions` / `rejected_approaches` / `open_threads`: the next PR touching those files will surface them.

## Design choices

- **New top-level subcommand, not under `node`** — operates on the whole graph, not a single node, so it parallels `context` / `search` / `graph`.
- **Exact-string artifact match in v1** — directory-prefix or fuzzy match deferred. False-positive comments are worse noise than false negatives. Recorded as an open thread on the work node.
- **Sorted by `created_at` desc** — reviewers care most about the latest context for each file.
- **Built from source in CI** — keeps the workflow self-contained and means the action always reflects the version of memex in the repo. External consumers swap the build step for `cargo install --locked memex-cli`.
- **Workflow file rather than a versioned reusable Action** — smaller surface to maintain for v1; promote to `.github/actions/memex-pr-context/` once the format stabilizes.

## Open threads (recorded on memex node `75387180`)

- Surface `open_threads` from ancestor nodes whose artifacts overlap, not just direct artifact matches.
- Add directory-prefix matching as opt-in once we see real usage.
- Cap output length when many nodes match (currently unbounded; could blow past GitHub comment size on large PRs).
- Extract to a versioned reusable Action once the format is stable.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` (40/40 pass)
- [x] Manual smoke: `./target/debug/memex pr-context --file src/store.rs --file .github/workflows/ci.yml` against this repo's real nodes returns the expected matches.
- [x] Manual smoke: `--file path/that/matches/nothing.rs` returns the empty-state message with the marker prefix.
- [x] **Reviewer to verify on this PR**: the `memex PR context` workflow runs, posts a single comment with the marker, and re-running (push another commit) updates the same comment in place rather than stacking new ones.