### PR TITLE
feat: add memex node auto for agent-authored node updates (closes #60)

### DIFF
--- a/.memex/nodes/ac428336-89fe-4bbe-9201-93eb79151a9a.json
+++ b/.memex/nodes/ac428336-89fe-4bbe-9201-93eb79151a9a.json
@@ -5,7 +5,7 @@
   ],
   "git_ref": "feat/node-auto (406ba54f)",
   "created_at": "2026-05-22T03:04:16.356229Z",
-  "updated_at": "2026-05-22T03:10:26.776496Z",
+  "updated_at": "2026-05-22T03:15:47.110466Z",
   "summary": {
     "goal": "Add 'memex node auto' subcommand: read a JSON payload of draft node additions, support --dry-run (default, prints a diff) and --apply (merge with dedupe-on-normalized-text). Closes #60.",
     "decisions": [
@@ -14,7 +14,8 @@
       "Normalize for dedupe = trim + collapse whitespace + lowercase + strip trailing .!? — handles common re-emit drift (whitespace, casing, trailing period) without crossing into fuzzy matching.",
       "Artifacts dedupe on exact path (no normalization) — paths are case-sensitive on most filesystems and trailing-punctuation stripping is wrong for them.",
       "Dry-run is the default action; --apply writes without a TTY confirmation. The dry-run-default gate IS the safety net — avoids a three-flag combo (--dry-run / --apply / --force).",
-      "Required --from-stdin (no implicit stdin read) — leaves room for a future --payload-file flag without ambiguity about where input comes from."
+      "Required --from-stdin (no implicit stdin read) — leaves room for a future --payload-file flag without ambiguity about where input comes from.",
+      "Skill guidance recommends node auto when there are 2+ updates in a row; single 'memex node edit' calls remain the lighter-weight path for one-off context."
     ],
     "rejected_approaches": [
       {
@@ -38,10 +39,12 @@
       "src/commands/node.rs",
       "src/main.rs",
       "src/models.rs",
-      "tests/integration_tests.rs"
+      "tests/integration_tests.rs",
+      "README.md",
+      "claude-plugin/skills/memex/SKILL.md"
     ]
   },
   "raw_transcript_ref": null,
   "tags": [],
-  "status": "Active"
+  "status": "Resolved"
 }

--- a/.memex/nodes/ac428336-89fe-4bbe-9201-93eb79151a9a.json
+++ b/.memex/nodes/ac428336-89fe-4bbe-9201-93eb79151a9a.json
@@ -1,0 +1,47 @@
+{
+  "id": "ac428336-89fe-4bbe-9201-93eb79151a9a",
+  "parent_ids": [
+    "8403a5cb-721b-4c62-b019-2d02ecff7c82"
+  ],
+  "git_ref": "feat/node-auto (406ba54f)",
+  "created_at": "2026-05-22T03:04:16.356229Z",
+  "updated_at": "2026-05-22T03:10:26.776496Z",
+  "summary": {
+    "goal": "Add 'memex node auto' subcommand: read a JSON payload of draft node additions, support --dry-run (default, prints a diff) and --apply (merge with dedupe-on-normalized-text). Closes #60.",
+    "decisions": [
+      "JSON payload format (not TOML) — issue example uses JSON and agents emit JSON natively. The existing --rejected TOML path on 'node edit' remains for humans typing on the CLI.",
+      "Goal deliberately omitted from payload — scope changes belong in explicit 'node edit --goal', not silent side effects of an agent turn.",
+      "Normalize for dedupe = trim + collapse whitespace + lowercase + strip trailing .!? — handles common re-emit drift (whitespace, casing, trailing period) without crossing into fuzzy matching.",
+      "Artifacts dedupe on exact path (no normalization) — paths are case-sensitive on most filesystems and trailing-punctuation stripping is wrong for them.",
+      "Dry-run is the default action; --apply writes without a TTY confirmation. The dry-run-default gate IS the safety net — avoids a three-flag combo (--dry-run / --apply / --force).",
+      "Required --from-stdin (no implicit stdin read) — leaves room for a future --payload-file flag without ambiguity about where input comes from."
+    ],
+    "rejected_approaches": [
+      {
+        "description": "TTY confirmation on --apply (consistent with resolve / abandon)",
+        "reason": "Open question from the issue. Resolved against: would require a third flag (--force) for a write operation, when --dry-run-default already provides the confirmation gate. Two flags is cleaner than three."
+      },
+      {
+        "description": "Fuzzy dedupe (Levenshtein/similarity threshold)",
+        "reason": "Listed as an option in the issue. Explicit non-goal for v1 — too easy to silently merge entries that look similar but mean different things. Punt to a follow-up if exact+normalized proves insufficient in practice."
+      },
+      {
+        "description": "Including goal in the JSON payload",
+        "reason": "Goal changes are scope shifts, not append-only context. Mixing them into an idempotent batch undermines the dry-run trust model. The agent can still run node edit --goal explicitly when scope actually changes."
+      }
+    ],
+    "open_threads": [
+      "Skill update needs a concrete prompt that constrains length and asks the agent to surface rejected alternatives explicitly — issue mentions this; will land in the docs commit.",
+      "Should the apply summary line collapse the four counters when several are zero? e.g. 'Applied 1 decision' instead of 'Applied 1 decision(s), 0 rejected approach(es), 0 open thread(s), 0 artifact(s)'. Current output is uniform but verbose."
+    ],
+    "key_artifacts": [
+      "src/commands/node.rs",
+      "src/main.rs",
+      "src/models.rs",
+      "tests/integration_tests.rs"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Active"
+}

--- a/README.md
+++ b/README.md
@@ -102,6 +102,39 @@ The `--rejected` flag expects inline TOML with `description` and `reason` fields
 memex node edit --rejected $'description = "Alternative approach"\nreason = "Why it was rejected"'
 ```
 
+### `memex node auto [id]`
+
+Apply agent-authored draft additions from a JSON payload on stdin. Designed for the case where an LLM agent has the conversation transcript and can draft node updates for the human to review, so curation becomes a side effect of doing the work rather than a separate task.
+
+| Flag | Effect |
+|---|---|
+| `--from-stdin` | Required. Read the JSON payload from stdin. |
+| `--dry-run` | Print the diff against the target node without writing (default). |
+| `--apply` | Write the merged additions to the node. Mutually exclusive with `--dry-run`. |
+
+The payload is a JSON object; every field is optional, so an agent can send only what it has for a given turn:
+
+```json
+{
+  "decisions": ["Use SQLite for v2 storage"],
+  "rejected_approaches": [
+    {"description": "Postgres", "reason": "Too heavyweight for a single-user CLI"}
+  ],
+  "open_threads": ["Audit fts5 stability"],
+  "key_artifacts": ["src/db.rs"]
+}
+```
+
+Re-running the same payload is a no-op. Free-text entries dedupe on normalized text (trim, collapse whitespace, lowercase, strip trailing `.!?`); artifacts dedupe on exact path. `goal` is **not** part of the payload — scope changes go through explicit `memex node edit --goal`.
+
+```bash
+# Preview (default):
+cat payload.json | memex node auto --from-stdin
+
+# Write:
+cat payload.json | memex node auto --from-stdin --apply
+```
+
 ### `memex node show [id]`
 
 Display a node's full summary.

--- a/claude-plugin/skills/memex/SKILL.md
+++ b/claude-plugin/skills/memex/SKILL.md
@@ -73,6 +73,33 @@ Use `--summary` only for a full bulk replacement (e.g. bootstrapping from a plan
 
 `--rejected` and `--open-thread` are the under-used fields. Using them is the difference between a node that captures *why* the work landed this way and one that only captures *what* shipped.
 
+### After a meaningful turn: batch updates with `node auto`
+
+After any turn that produced a real decision, ruled out an alternative, or surfaced a follow-up — i.e. you'd otherwise be running 2+ `node edit` flags in a row — draft a JSON payload and show the human the dry-run diff first:
+
+```bash
+cat <<'EOF' | memex node auto --from-stdin
+{
+  "decisions": ["chose X over Y because Z"],
+  "rejected_approaches": [
+    {"description": "alternative you considered", "reason": "why it didn't win"}
+  ],
+  "open_threads": ["question to revisit"],
+  "key_artifacts": ["path/to/key/file"]
+}
+EOF
+```
+
+The dry-run is the default and writes nothing. After the human confirms, re-run with `--apply`. Re-running an identical payload is a no-op (normalized-text dedupe), so it's safe to retry.
+
+Constraints for the payload itself:
+
+- Keep entries short and concrete — one specific decision per entry, not paragraphs. If you can't summarize the *why* in one sentence, the decision probably isn't crystallized yet.
+- For every decision, explicitly consider what alternative you didn't take. Empty `rejected_approaches` is a signal you skipped the question, not that there was no alternative.
+- Don't include `goal` — scope changes go through explicit `memex node edit --goal "..."`, not silent side effects.
+
+Use single `memex node edit --decision/...` calls when there's only one thing to record. Use `node auto` when there are several and you want a single review gate.
+
 ## Finishing
 
 1. Run the project's verification commands (lint, format, tests). All must pass before resolving.

--- a/src/commands/node.rs
+++ b/src/commands/node.rs
@@ -1,11 +1,12 @@
-use std::io::{self, IsTerminal, Write};
+use std::collections::HashSet;
+use std::io::{self, IsTerminal, Read, Write};
 
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
 
 use crate::editor;
 use crate::git;
-use crate::models::{ConversationNode, NodeStatus, NodeSummary};
+use crate::models::{ConversationNode, NodeAutoPayload, NodeStatus, NodeSummary, RejectedApproach};
 use crate::store::GraphStore;
 
 pub fn create(
@@ -119,6 +120,291 @@ pub fn edit(
 
     println!("Node {} updated.", node.short_id());
     Ok(())
+}
+
+/// Append draft node additions from a JSON payload on stdin.
+///
+/// `--dry-run` (default) prints a diff against the target node without
+/// writing. `--apply` merges the additions into the node summary, using
+/// normalized-text dedupe so re-running the same payload is a no-op.
+///
+/// The payload must be a JSON object; all fields are optional:
+///
+/// ```json
+/// {
+///   "decisions": ["..."],
+///   "rejected_approaches": [{"description": "...", "reason": "..."}],
+///   "open_threads": ["..."],
+///   "key_artifacts": ["..."]
+/// }
+/// ```
+pub fn auto(id: Option<&str>, from_stdin: bool, apply: bool) -> Result<()> {
+    if !from_stdin {
+        bail!(
+            "--from-stdin is required: pipe a JSON payload on stdin (see `memex node auto --help`)"
+        );
+    }
+
+    let mut payload_str = String::new();
+    io::stdin()
+        .read_to_string(&mut payload_str)
+        .context("Failed to read payload from stdin")?;
+
+    if payload_str.trim().is_empty() {
+        bail!("Empty payload on stdin (expected a JSON object)");
+    }
+
+    let payload: NodeAutoPayload =
+        serde_json::from_str(&payload_str).context("Failed to parse JSON payload")?;
+
+    let store = GraphStore::open_from_cwd()?;
+    let node_id = store.resolve_node_id(id)?;
+    let mut node = store.load_node(node_id)?;
+
+    let plan = compute_auto_plan(&node.summary, &payload);
+
+    if !apply {
+        print_auto_diff(&node, &plan);
+        return Ok(());
+    }
+
+    if !plan.has_changes() {
+        println!(
+            "✓ No changes — all entries already present on node {}.",
+            node.short_id()
+        );
+        return Ok(());
+    }
+
+    let counts = plan.counts();
+    node.summary.decisions.extend(plan.new_decisions);
+    node.summary
+        .rejected_approaches
+        .extend(plan.new_rejected.into_iter().map(|r| RejectedApproach {
+            description: r.description,
+            reason: r.reason,
+        }));
+    node.summary.open_threads.extend(plan.new_open_threads);
+    node.summary.key_artifacts.extend(plan.new_artifacts);
+    node.updated_at = Utc::now();
+    store.save_node(&node)?;
+
+    println!(
+        "✓ Applied {} decision(s), {} rejected approach(es), {} open thread(s), {} artifact(s) to node {}.",
+        counts.decisions, counts.rejected, counts.open_threads, counts.artifacts,
+        node.short_id()
+    );
+    Ok(())
+}
+
+/// Result of comparing a payload against an existing node summary: what
+/// would be added on `--apply`, and what was skipped as a duplicate.
+struct AutoPlan {
+    new_decisions: Vec<String>,
+    skipped_decisions: Vec<String>,
+    new_rejected: Vec<crate::models::RejectedApproachPayload>,
+    skipped_rejected: Vec<String>,
+    new_open_threads: Vec<String>,
+    skipped_open_threads: Vec<String>,
+    new_artifacts: Vec<String>,
+    skipped_artifacts: Vec<String>,
+}
+
+struct AutoCounts {
+    decisions: usize,
+    rejected: usize,
+    open_threads: usize,
+    artifacts: usize,
+}
+
+impl AutoPlan {
+    fn has_changes(&self) -> bool {
+        !self.new_decisions.is_empty()
+            || !self.new_rejected.is_empty()
+            || !self.new_open_threads.is_empty()
+            || !self.new_artifacts.is_empty()
+    }
+
+    fn has_skips(&self) -> bool {
+        !self.skipped_decisions.is_empty()
+            || !self.skipped_rejected.is_empty()
+            || !self.skipped_open_threads.is_empty()
+            || !self.skipped_artifacts.is_empty()
+    }
+
+    fn counts(&self) -> AutoCounts {
+        AutoCounts {
+            decisions: self.new_decisions.len(),
+            rejected: self.new_rejected.len(),
+            open_threads: self.new_open_threads.len(),
+            artifacts: self.new_artifacts.len(),
+        }
+    }
+}
+
+/// Normalize free-text entries for dedupe: trim, collapse internal
+/// whitespace, lowercase, strip trailing punctuation. This catches the
+/// common cases (re-run with the same payload, agent re-emitting with a
+/// trailing period) without crossing into fuzzy matching.
+fn normalize_text(s: &str) -> String {
+    let collapsed: String = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    let lower = collapsed.to_lowercase();
+    lower.trim_end_matches(['.', '!', '?']).to_string()
+}
+
+fn compute_auto_plan(summary: &NodeSummary, payload: &NodeAutoPayload) -> AutoPlan {
+    // Text fields: normalized-text dedupe.
+    let mut decision_keys: HashSet<String> = summary
+        .decisions
+        .iter()
+        .map(|d| normalize_text(d))
+        .collect();
+    let mut new_decisions = Vec::new();
+    let mut skipped_decisions = Vec::new();
+    for d in &payload.decisions {
+        let key = normalize_text(d);
+        if key.is_empty() {
+            // Drop empties silently — agents occasionally emit blanks.
+            continue;
+        }
+        if decision_keys.insert(key) {
+            new_decisions.push(d.trim().to_string());
+        } else {
+            skipped_decisions.push(d.trim().to_string());
+        }
+    }
+
+    // Rejected approaches: dedupe on normalized description only;
+    // reasons are usually longer and less stable across re-emits.
+    let mut rejected_keys: HashSet<String> = summary
+        .rejected_approaches
+        .iter()
+        .map(|r| normalize_text(&r.description))
+        .collect();
+    let mut new_rejected = Vec::new();
+    let mut skipped_rejected = Vec::new();
+    for r in &payload.rejected_approaches {
+        let key = normalize_text(&r.description);
+        if key.is_empty() {
+            continue;
+        }
+        if rejected_keys.insert(key) {
+            new_rejected.push(crate::models::RejectedApproachPayload {
+                description: r.description.trim().to_string(),
+                reason: r.reason.trim().to_string(),
+            });
+        } else {
+            skipped_rejected.push(r.description.trim().to_string());
+        }
+    }
+
+    let mut thread_keys: HashSet<String> = summary
+        .open_threads
+        .iter()
+        .map(|t| normalize_text(t))
+        .collect();
+    let mut new_open_threads = Vec::new();
+    let mut skipped_open_threads = Vec::new();
+    for t in &payload.open_threads {
+        let key = normalize_text(t);
+        if key.is_empty() {
+            continue;
+        }
+        if thread_keys.insert(key) {
+            new_open_threads.push(t.trim().to_string());
+        } else {
+            skipped_open_threads.push(t.trim().to_string());
+        }
+    }
+
+    // Artifacts: exact-path dedupe (paths are case-sensitive on most
+    // filesystems and shouldn't have punctuation normalized away).
+    let mut artifact_keys: HashSet<String> = summary.key_artifacts.iter().cloned().collect();
+    let mut new_artifacts = Vec::new();
+    let mut skipped_artifacts = Vec::new();
+    for a in &payload.key_artifacts {
+        let trimmed = a.trim().to_string();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if artifact_keys.insert(trimmed.clone()) {
+            new_artifacts.push(trimmed);
+        } else {
+            skipped_artifacts.push(trimmed);
+        }
+    }
+
+    AutoPlan {
+        new_decisions,
+        skipped_decisions,
+        new_rejected,
+        skipped_rejected,
+        new_open_threads,
+        skipped_open_threads,
+        new_artifacts,
+        skipped_artifacts,
+    }
+}
+
+fn print_auto_diff(node: &ConversationNode, plan: &AutoPlan) {
+    let goal_preview: String = node.summary.goal.chars().take(60).collect();
+    let goal_preview = if node.summary.goal.len() > 60 {
+        format!("{}…", goal_preview)
+    } else {
+        goal_preview
+    };
+    println!("Node: {} ({})", node.short_id(), goal_preview);
+    println!();
+
+    if !plan.has_changes() {
+        println!("No changes — all entries already present.");
+        return;
+    }
+
+    if !plan.new_decisions.is_empty() {
+        println!("+ Decisions:");
+        for d in &plan.new_decisions {
+            println!("+   • {}", d);
+        }
+    }
+    if !plan.new_rejected.is_empty() {
+        println!("+ Rejected Approaches:");
+        for r in &plan.new_rejected {
+            println!("+   ✗ {} — {}", r.description, r.reason);
+        }
+    }
+    if !plan.new_open_threads.is_empty() {
+        println!("+ Open Threads:");
+        for t in &plan.new_open_threads {
+            println!("+   ? {}", t);
+        }
+    }
+    if !plan.new_artifacts.is_empty() {
+        println!("+ Key Artifacts:");
+        for a in &plan.new_artifacts {
+            println!("+   ◆ {}", a);
+        }
+    }
+
+    if plan.has_skips() {
+        println!();
+        println!("Skipped (already present):");
+        for d in &plan.skipped_decisions {
+            println!("  • {}", d);
+        }
+        for r in &plan.skipped_rejected {
+            println!("  ✗ {}", r);
+        }
+        for t in &plan.skipped_open_threads {
+            println!("  ? {}", t);
+        }
+        for a in &plan.skipped_artifacts {
+            println!("  ◆ {}", a);
+        }
+    }
+
+    println!();
+    println!("Run with --apply to write these changes.");
 }
 
 pub fn show(id: Option<&str>) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,24 @@ enum NodeCommands {
         rejected: Vec<String>,
     },
 
+    /// Apply agent-authored draft additions from a JSON payload on stdin
+    Auto {
+        /// Node ID (defaults to active node)
+        id: Option<String>,
+
+        /// Read the JSON payload from stdin (required)
+        #[arg(long = "from-stdin")]
+        from_stdin: bool,
+
+        /// Write the merged additions to the node (mutually exclusive with --dry-run)
+        #[arg(long, conflicts_with = "dry_run")]
+        apply: bool,
+
+        /// Print the diff against the active node without writing (default)
+        #[arg(long = "dry-run", conflicts_with = "apply")]
+        dry_run: bool,
+    },
+
     /// Show a node's full summary
     Show {
         /// Node ID (defaults to active node)
@@ -208,6 +226,12 @@ fn run(cli: Cli) -> Result<()> {
                 &open_thread,
                 &rejected,
             ),
+            NodeCommands::Auto {
+                id,
+                from_stdin,
+                apply,
+                dry_run: _,
+            } => commands::node::auto(id.as_deref(), from_stdin, apply),
             NodeCommands::Show { id } => commands::node::show(id.as_deref()),
             NodeCommands::List => commands::node::list(),
             NodeCommands::Resolve { id, force } => {

--- a/src/models.rs
+++ b/src/models.rs
@@ -142,6 +142,28 @@ impl From<NodeSummaryToml> for NodeSummary {
     }
 }
 
+/// JSON payload accepted by `memex node auto` — every field is optional so
+/// agents can emit only what they have for a given turn. `goal` is
+/// deliberately omitted; scope changes should go through explicit
+/// `node edit --goal`.
+#[derive(Debug, Default, Deserialize)]
+pub struct NodeAutoPayload {
+    #[serde(default)]
+    pub decisions: Vec<String>,
+    #[serde(default)]
+    pub rejected_approaches: Vec<RejectedApproachPayload>,
+    #[serde(default)]
+    pub open_threads: Vec<String>,
+    #[serde(default)]
+    pub key_artifacts: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RejectedApproachPayload {
+    pub description: String,
+    pub reason: String,
+}
+
 /// Config file structure
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Config {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -298,6 +298,235 @@ fn node_edit_empty_goal_fails() {
         .stderr(predicate::str::contains("cannot be empty").or(predicate::str::contains("empty")));
 }
 
+// ─── Node auto ───────────────────────────────────────────────────────────────
+
+#[test]
+fn node_auto_dry_run_prints_diff_without_writing() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Auto-target");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", "--from-stdin"])
+        .write_stdin(
+            r#"{"decisions":["Use SQLite"],"open_threads":["audit fts5"],"key_artifacts":["src/db.rs"]}"#,
+        )
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("+ Decisions:"))
+        .stdout(predicate::str::contains("Use SQLite"))
+        .stdout(predicate::str::contains("audit fts5"))
+        .stdout(predicate::str::contains("src/db.rs"))
+        .stdout(predicate::str::contains("Run with --apply"));
+
+    // Verify nothing was written: the show output should not contain the
+    // dry-run additions.
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Use SQLite").not())
+        .stdout(predicate::str::contains("audit fts5").not());
+}
+
+#[test]
+fn node_auto_apply_writes_all_fields() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Auto-apply");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", "--from-stdin", "--apply"])
+        .write_stdin(
+            r#"{
+              "decisions":["Use SQLite"],
+              "rejected_approaches":[{"description":"Postgres","reason":"Too heavyweight"}],
+              "open_threads":["audit fts5"],
+              "key_artifacts":["src/db.rs"]
+            }"#,
+        )
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Applied 1 decision"));
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Use SQLite"))
+        .stdout(predicate::str::contains("Postgres — Too heavyweight"))
+        .stdout(predicate::str::contains("audit fts5"))
+        .stdout(predicate::str::contains("src/db.rs"));
+}
+
+#[test]
+fn node_auto_apply_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Idempotent");
+
+    let payload = r#"{"decisions":["Use SQLite"],"key_artifacts":["src/db.rs"]}"#;
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", "--from-stdin", "--apply"])
+        .write_stdin(payload)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Applied"));
+
+    // Second apply with identical payload: no-op.
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", "--from-stdin", "--apply"])
+        .write_stdin(payload)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No changes"));
+}
+
+#[test]
+fn node_auto_dedupes_on_normalized_text() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Dedupe");
+
+    // First write the canonical form.
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", "--from-stdin", "--apply"])
+        .write_stdin(r#"{"decisions":["Use SQLite for storage"]}"#)
+        .assert()
+        .success();
+
+    // Re-emit with extra whitespace, different case, and a trailing
+    // period. Normalized dedupe should treat it as a duplicate.
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", "--from-stdin", "--apply"])
+        .write_stdin(r#"{"decisions":["  use   sqlite for storage. "]}"#)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No changes"));
+}
+
+#[test]
+fn node_auto_requires_from_stdin() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Needs-flag");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--from-stdin is required"));
+}
+
+#[test]
+fn node_auto_empty_payload_errors() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Empty");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", "--from-stdin"])
+        .write_stdin("")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Empty payload"));
+}
+
+#[test]
+fn node_auto_invalid_json_errors() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Bad-json");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", "--from-stdin"])
+        .write_stdin("not json")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to parse JSON"));
+}
+
+#[test]
+fn node_auto_apply_and_dry_run_are_exclusive() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Conflict");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", "--from-stdin", "--apply", "--dry-run"])
+        .write_stdin("{}")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn node_auto_targets_explicit_id() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    let target = create_node(&tmp, "Target");
+    // Make a second node active so the auto must use the explicit id arg.
+    create_node(&tmp, "Different active");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", &target, "--from-stdin", "--apply"])
+        .write_stdin(r#"{"decisions":["Routed to target"]}"#)
+        .assert()
+        .success();
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "show", &target])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Routed to target"));
+}
+
+#[test]
+fn node_auto_no_active_node_errors() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    // No node create → init left active pointing at the root, so call auto
+    // against a node id we know does not exist.
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", "deadbeef", "--from-stdin"])
+        .write_stdin(r#"{"decisions":["x"]}"#)
+        .assert()
+        .failure();
+}
+
+#[test]
+fn node_auto_partial_payload_only_new_section() {
+    let tmp = TempDir::new().unwrap();
+    init_in(&tmp);
+    create_node(&tmp, "Partial");
+
+    memex()
+        .current_dir(tmp.path())
+        .args(["node", "auto", "--from-stdin"])
+        .write_stdin(r#"{"open_threads":["follow up later"]}"#)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("+ Open Threads:"))
+        .stdout(predicate::str::contains("+ Decisions:").not())
+        .stdout(predicate::str::contains("+ Rejected Approaches:").not())
+        .stdout(predicate::str::contains("+ Key Artifacts:").not());
+}
+
 // ─── Node status ─────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds a new `memex node auto [id] --from-stdin [--apply | --dry-run]` subcommand that reads a JSON payload of draft node additions (decisions, rejected approaches, open threads, key artifacts) and either prints a diff (default) or merges it into the target node — so an agent can record context as a side effect of a turn instead of as a separate task, with a human review gate.
- Dedupes on re-run: free-text fields normalize via trim + collapse whitespace + lowercase + strip trailing `.!?`; artifacts dedupe on exact path. Re-applying the same payload is a no-op.
- `goal` is deliberately excluded from the payload — scope changes go through explicit `node edit --goal` rather than silent side effects of an agent turn.
- Documents the new command in README and updates the memex Claude skill with guidance on when to invoke it (any turn with 2+ updates) and constraints on payload entries.

Closes #60.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --all-targets` — 69 unit + 52 integration tests, all pass (11 new tests cover dry-run-no-write, apply, idempotency, normalized dedupe, missing `--from-stdin`, empty / invalid payload, mutually-exclusive flags, explicit `[id]` target, no-active-node error, partial payload)
- [x] Dogfooded: this PR's memex node was updated via `node auto --apply` itself, confirming the dry-run/apply contract and idempotency end-to-end