### PR TITLE
chore: release v0.2.0

### DIFF
--- a/.memex/nodes/03a1d310-33e0-46a6-8138-35d247a8b494.json
+++ b/.memex/nodes/03a1d310-33e0-46a6-8138-35d247a8b494.json
@@ -1,0 +1,24 @@
+{
+  "id": "03a1d310-33e0-46a6-8138-35d247a8b494",
+  "parent_ids": [
+    "50c6da9b-fda1-475e-8d88-1882f2d52825"
+  ],
+  "git_ref": "release/v0.2.0 (a2fe32f0)",
+  "created_at": "2026-05-22T05:24:33.275709Z",
+  "updated_at": "2026-05-22T05:26:21.274733Z",
+  "summary": {
+    "goal": "Release v0.2.0",
+    "decisions": [],
+    "rejected_approaches": [],
+    "open_threads": [],
+    "key_artifacts": [
+      "Cargo.toml",
+      "CHANGELOG.md"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [
+    "release"
+  ],
+  "status": "Resolved"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-22
+
+### Added
+
+- `memex pr-context <ref>` — search the graph for nodes matching a git ref (branch name, commit SHA, or PR number) and emit a Markdown payload of the most-recent matches, intended to be posted as a PR comment. `--limit N` caps the output (default 5).
+- GitHub Action workflow that posts a `memex pr-context` comment to each PR automatically.
+- `memex node auto <json>` — non-interactive edit subcommand for agent-authored updates. Accepts a JSON payload with `decisions`, `artifacts`, `open_threads`, and `rejected` arrays and applies them to the active node in one call.
+
+### Changed
+
+- README lede reframed around how memex compares with ADRs and changelogs as a navigable DAG of conversation nodes.
+- Release-cut workflow is now tracked as a memex node, so each release shipped from this repo carries its own graph context.
+
 ## [0.1.0] - 2026-05-11
 
 The first tagged release of memex — a CLI for organizing AI-assisted development as a versioned, navigable DAG of conversation nodes.
@@ -28,5 +41,6 @@ The first tagged release of memex — a CLI for organizing AI-assisted developme
 - Claude Code plugin under `claude-plugin/` shipping a `memex` skill that triggers in any repo with a `.memex/` directory.
 - Release workflow (`.github/workflows/release.yml`) builds binaries for `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-apple-darwin`, and `x86_64-pc-windows-msvc`, attaches them with SHA-256 checksums to a draft GitHub release, and publishes to crates.io on tag push.
 
-[Unreleased]: https://github.com/maxrios/memex/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/maxrios/memex/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/maxrios/memex/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/maxrios/memex/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memex-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memex-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.74"
 description = "A CLI tool for organizing AI-assisted development into a versioned, navigable DAG of conversation nodes."


### PR DESCRIPTION
## Summary

Release-prep PR for v0.2.0. See node `03a1d310` for full context.

- Bump `Cargo.toml` to `0.2.0`; refresh `Cargo.lock`.
- Roll `CHANGELOG.md`: move Unreleased content into `[0.2.0] - 2026-05-22` and update compare links.
- Record the release node JSON.

### What ships in 0.2.0

**Added**
- `memex pr-context <ref>` — emit a Markdown payload of nodes matching a git ref (branch / commit / PR number); `--limit N` caps output.
- GitHub Action workflow that posts a `memex pr-context` comment on each PR.
- `memex node auto <json>` — non-interactive edit subcommand for agent-authored updates to the active node.

**Changed**
- README lede reframed around how memex compares with ADRs and changelogs as a navigable DAG.
- Release-cut workflow now tracked as a memex node.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` — 52 passed
- [x] `cargo package --no-verify` — 84 files, 309.6 KiB
- [x] CI green on this PR
- [x] `memex-check` green on this PR