### PR TITLE
chore: release v0.2.1

### DIFF
--- a/.memex/nodes/c5bf0834-7f68-499a-81b7-f67133f5d3ec.json
+++ b/.memex/nodes/c5bf0834-7f68-499a-81b7-f67133f5d3ec.json
@@ -1,0 +1,26 @@
+{
+  "id": "c5bf0834-7f68-499a-81b7-f67133f5d3ec",
+  "parent_ids": [
+    "deb5bf0d-47b8-4e70-96d9-aced3960d648"
+  ],
+  "git_ref": "release/v0.2.1 (fa0b2438)",
+  "created_at": "2026-05-24T02:11:00.792224Z",
+  "updated_at": "2026-05-24T02:12:07.349616Z",
+  "summary": {
+    "goal": "Release v0.2.1",
+    "decisions": [
+      "Patch-level bump (0.2.0 → 0.2.1): no source changes since v0.2.0, only Renovate-driven dependency updates (toml 1.0, assert_cmd/predicates pin, serde_json/uuid/clap minor refreshes) and CI action bumps (checkout, cache, github-script, artifact actions, gh-release). Stays in SemVer PATCH because no API or CLI surface changed."
+    ],
+    "rejected_approaches": [],
+    "open_threads": [],
+    "key_artifacts": [
+      "Cargo.toml",
+      "CHANGELOG.md"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [
+    "release"
+  ],
+  "status": "Resolved"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-23
+
+### Changed
+
+- Dependency maintenance: bumped `toml` to 1.0, pinned `assert_cmd` to 2.2.2 and `predicates` to 3.1.4, refreshed `serde_json`, `uuid`, and `clap` minor/patch updates via Renovate.
+- CI maintenance: pinned and refreshed `actions/checkout`, `actions/cache`, `actions/github-script`, `actions/upload-artifact`/`download-artifact`, and `softprops/action-gh-release` to current major versions via Renovate.
+- Renovate configured for the repo: groups GitHub Actions updates with a 14-day cooldown, auto-merges patch/minor/digest bumps, and prefixes Renovate commits/PR titles with `[skip memex]` so they bypass `memex-check`.
+
 ## [0.2.0] - 2026-05-22
 
 ### Added
@@ -41,6 +49,7 @@ The first tagged release of memex — a CLI for organizing AI-assisted developme
 - Claude Code plugin under `claude-plugin/` shipping a `memex` skill that triggers in any repo with a `.memex/` directory.
 - Release workflow (`.github/workflows/release.yml`) builds binaries for `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-apple-darwin`, and `x86_64-pc-windows-msvc`, attaches them with SHA-256 checksums to a draft GitHub release, and publishes to crates.io on tag push.
 
-[Unreleased]: https://github.com/maxrios/memex/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/maxrios/memex/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/maxrios/memex/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/maxrios/memex/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/maxrios/memex/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memex-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memex-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.74"
 description = "A CLI tool for organizing AI-assisted development into a versioned, navigable DAG of conversation nodes."


### PR DESCRIPTION
## Summary

- Patch release covering dependency and CI maintenance since v0.2.0; no source or CLI surface changes.
- Bumps `Cargo.toml` to 0.2.1, rolls `CHANGELOG.md`, and adds the release node `c5bf0834`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` (52 passed)
- [x] `cargo package --no-verify`
- [x] CI green on this PR (fmt, clippy, tests across Linux/macOS/Windows, `memex-check`)
- [x] After merge: tag `v0.2.1` on `main`, watch release workflow, confirm crates.io publish + draft release archives, then promote draft to published.

See node c5bf0834 for release context.