### PR TITLE
docs: fix --tag → --tags in node create examples

### DIFF
--- a/.memex/nodes/cc9ff694-a924-4777-bd26-b39fc69e73e6.json
+++ b/.memex/nodes/cc9ff694-a924-4777-bd26-b39fc69e73e6.json
@@ -1,0 +1,26 @@
+{
+  "id": "cc9ff694-a924-4777-bd26-b39fc69e73e6",
+  "parent_ids": [
+    "c5bf0834-7f68-499a-81b7-f67133f5d3ec"
+  ],
+  "git_ref": "docs/releasing-tags-flag (90ce8441)",
+  "created_at": "2026-05-24T02:18:25.989338Z",
+  "updated_at": "2026-05-24T02:19:07.497069Z",
+  "summary": {
+    "goal": "Fix --tag → --tags typo in RELEASING.md and README.md examples",
+    "decisions": [
+      "All three doc instances use --tags (plural) since that is the actual flag clap derives from the field name; verified with 'memex node create --help'."
+    ],
+    "rejected_approaches": [],
+    "open_threads": [
+      "CHANGELOG.md:38 also says 'optionally `--tag`' for the v0.1 entry. Historical note; left untouched to avoid retroactively editing past changelog entries."
+    ],
+    "key_artifacts": [
+      "RELEASING.md",
+      "README.md"
+    ]
+  },
+  "raw_transcript_ref": null,
+  "tags": [],
+  "status": "Resolved"
+}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cargo run -- <command>
 memex init
 
 # Create a node for a new feature
-memex node create --parent <root-id> --goal "Add user authentication" --tag auth
+memex node create --parent <root-id> --goal "Add user authentication" --tags auth
 
 # During implementation, record decisions and artifacts incrementally
 memex node edit --decision "Used JWT over session cookies for statelessness"
@@ -81,7 +81,7 @@ Create a new conversation node.
 | `--parent <id>` | Parent node ID |
 | `--goal "..."` | One-line goal for this node |
 | `--git-ref <ref>` | Git branch or tag to associate |
-| `--tag <tag>` | Tag the node (repeatable) |
+| `--tags <tag>` | Tag the node (repeatable) |
 
 ### `memex node edit [id]`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,7 +22,7 @@ Each release is itself tracked as a memex node so the graph captures *what shipp
 3. **Create the release node.** Parent is the tip of `main` (find via `memex node list` or `memex graph view`):
 
    ```
-   memex node create --parent <main-tip-id> --goal "Release v<version>" --tag release
+   memex node create --parent <main-tip-id> --goal "Release v<version>" --tags release
    ```
 
 4. **Bump the version.** Edit `version` in `Cargo.toml`, then run `cargo build` once so `Cargo.lock` picks up the new version.


### PR DESCRIPTION
## Summary

- Fix `--tag` → `--tags` in the `memex node create` example in [RELEASING.md:25](RELEASING.md:25). The actual clap-derived flag is `--tags` (plural); `--tag` errors with `unexpected argument '--tag' found; tip: a similar argument exists: '--tags'`.
- Same fix in two spots in [README.md](README.md): the quick-start example (line 47) and the flag reference table (line 84).
- Docs-only — no source changes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` (52 passed)
- [x] Verified flag name with `cargo run -- node create --help` — shows `--tags <tag>`
- [ ] Reviewer: confirm CHANGELOG.md:38 (`optionally \`--tag\``) should stay as-is since it's a historical v0.1 entry — left untouched to avoid retroactively editing past changelog entries